### PR TITLE
App の initializer, entry_point の返り値を void から RESULT にする

### DIFF
--- a/Applications/divided_cmd_utility.c
+++ b/Applications/divided_cmd_utility.c
@@ -16,13 +16,14 @@
 #include "../TlmCmd/common_cmd_packet_util.h"
 #include "../System/TimeManager/time_manager.h"
 #include "../System/EventManager/event_logger.h"
+#include "../Library/result.h"
 
 /**
  * @brief  App初期化関数
  * @param  void
- * @return void
+ * @return RESULT
  */
-static void DCU_init_(void);
+static RESULT DCU_init_(void);
 
 /**
  * @brief  ログクリア
@@ -79,9 +80,10 @@ AppInfo DCU_create_app(void)
 }
 
 
-static void DCU_init_(void)
+static RESULT DCU_init_(void)
 {
   DCU_clear_log_();
+  return RESULT_OK;
 }
 
 

--- a/Applications/event_utility.c
+++ b/Applications/event_utility.c
@@ -7,11 +7,12 @@
 #include "event_utility.h"
 #include "../System/EventManager/event_handler.h"
 #include "../TlmCmd/common_cmd_packet_util.h"
+#include "../Library/result.h"
 
 #include <stddef.h> // for NULL
 
-static void EVENT_UTIL_init_(void);
-static void EVENT_UTIL_update_(void);
+static RESULT EVENT_UTIL_init_(void);
+static RESULT EVENT_UTIL_update_(void);
 
 static EventUtility event_utility_;
 const EventUtility* const event_utility = &event_utility_;
@@ -21,17 +22,19 @@ AppInfo EVENT_UTIL_create_app(void)
   return AI_create_app_info("event_util", EVENT_UTIL_init_, EVENT_UTIL_update_);
 }
 
-static void EVENT_UTIL_init_(void)
+static RESULT EVENT_UTIL_init_(void)
 {
   event_utility_.is_enabled_eh_execution = 1;
+  return RESULT_OK;
 }
 
-static void EVENT_UTIL_update_(void)
+static RESULT EVENT_UTIL_update_(void)
 {
   if (event_utility_.is_enabled_eh_execution)
   {
     EH_execute();
   }
+  return RESULT_OK;
 }
 
 CCP_CmdRet Cmd_EVENT_UTIL_ENABLE_EH_EXEC(const CommonCmdPacket* packet)

--- a/Applications/gs_command_dispatcher.c
+++ b/Applications/gs_command_dispatcher.c
@@ -7,6 +7,7 @@
 #include "gs_command_dispatcher.h"
 #include "../TlmCmd/packet_handler.h"
 #include "../TlmCmd/common_cmd_packet_util.h"
+#include "../Library/result.h"
 
 static CommandDispatcher gs_command_dispatcher_;
 const CommandDispatcher* const gs_command_dispatcher = &gs_command_dispatcher_;
@@ -14,9 +15,9 @@ const CommandDispatcher* const gs_command_dispatcher = &gs_command_dispatcher_;
 /**
  * @brief  GSCD App 初期化関数
  * @param  void
- * @return void
+ * @return RESULT
  */
-static void GSCD_init_(void);
+static RESULT GSCD_init_(void);
 
 /**
  * @brief  GSCD App 実行関数
@@ -24,9 +25,9 @@ static void GSCD_init_(void);
  *         PH_add_gs_cmd_ にて， GS からの RTC が gs_command_dispatcher に紐付けられたコマンドキュー PH_gs_cmd_list に push back される．
  *         そのキューから１つコマンドを取り出し実行する
  * @param  void
- * @return void
+ * @return RESULT
  */
-static void GSCD_dispatch_(void);
+static RESULT GSCD_dispatch_(void);
 
 
 AppInfo GSCD_create_app(void)
@@ -34,14 +35,16 @@ AppInfo GSCD_create_app(void)
   return AI_create_app_info("gs_command_dispatcher", GSCD_init_, GSCD_dispatch_);
 }
 
-static void GSCD_init_(void)
+static RESULT GSCD_init_(void)
 {
   gs_command_dispatcher_ = CDIS_init(&PH_gs_cmd_list);
+  return RESULT_OK;
 }
 
-static void GSCD_dispatch_(void)
+static RESULT GSCD_dispatch_(void)
 {
   CDIS_dispatch_command(&gs_command_dispatcher_);
+  return RESULT_OK;
 }
 
 CCP_CmdRet Cmd_GSCD_CLEAR_ERR_LOG(const CommonCmdPacket* packet)

--- a/Applications/memory_dump.c
+++ b/Applications/memory_dump.c
@@ -7,6 +7,7 @@
 #include "../TlmCmd/packet_handler.h"
 #include "../Library/endian.h"
 #include "../TlmCmd/common_cmd_packet_util.h"
+#include "../Library/result.h"
 
 static MemoryDump memory_dump_;
 const MemoryDump* const memory_dump = &memory_dump_;
@@ -17,7 +18,7 @@ const MemoryDump* const memory_dump = &memory_dump_;
 static CommonTlmPacket MEM_ctp_; // データサイズが大きいのでstatic確保
 #endif
 
-static void MEM_init_(void);
+static RESULT MEM_init_(void);
 
 static uint8_t MEM_get_next_adu_counter_(void);
 
@@ -50,13 +51,14 @@ AppInfo MEM_create_app(void)
   return AI_create_app_info("mem", MEM_init_, NULL);
 }
 
-static void MEM_init_(void)
+static RESULT MEM_init_(void)
 {
   memory_dump_.begin = 0;
   memory_dump_.end = 0;
   memory_dump_.adu_size = 0;
   memory_dump_.adu_seq = 0;
   memory_dump_.adu_counter = 0;
+  return RESULT_OK;
 }
 
 CCP_CmdRet Cmd_MEM_SET_REGION(const CommonCmdPacket* packet)

--- a/Applications/nop.c
+++ b/Applications/nop.c
@@ -8,16 +8,18 @@
 #include "nop.h"
 #include <stddef.h>
 #include "../TlmCmd/common_cmd_packet_util.h"
+#include "../Library/result.h"
 
-static void NOP_nop_(void);
+static RESULT NOP_nop_(void);
 
 AppInfo NOP_create_app(void)
 {
   return AI_create_app_info("nop", NULL, NOP_nop_);
 }
 
-static void NOP_nop_(void) {
+static RESULT NOP_nop_(void) {
   // no operation
+  return RESULT_OK;
 }
 
 CCP_CmdRet Cmd_NOP(const CommonCmdPacket* packet)

--- a/Applications/realtime_command_dispatcher.c
+++ b/Applications/realtime_command_dispatcher.c
@@ -2,26 +2,29 @@
 #include "realtime_command_dispatcher.h"
 #include "../TlmCmd/packet_handler.h"
 #include "../TlmCmd/common_cmd_packet_util.h"
+#include "../Library/result.h"
 
 static CommandDispatcher realtime_command_dispatcher_;
 const CommandDispatcher* const realtime_command_dispatcher = &realtime_command_dispatcher_;
 
-static void RTCD_init_(void);
-static void RTCD_dispatch_(void);
+static RESULT RTCD_init_(void);
+static RESULT RTCD_dispatch_(void);
 
 AppInfo RTCD_create_app(void)
 {
   return AI_create_app_info("realtime_command_dispatcher", RTCD_init_, RTCD_dispatch_);
 }
 
-static void RTCD_init_(void)
+static RESULT RTCD_init_(void)
 {
   realtime_command_dispatcher_ = CDIS_init(&PH_rt_cmd_list);
+  return RESULT_OK;
 }
 
-static void RTCD_dispatch_(void)
+static RESULT RTCD_dispatch_(void)
 {
   CDIS_dispatch_command(&realtime_command_dispatcher_);
+  return RESULT_OK;
 }
 
 CCP_CmdRet Cmd_RTCD_CLEAR_ALL_REALTIME(const CommonCmdPacket* packet)

--- a/Applications/telemetry_manager.c
+++ b/Applications/telemetry_manager.c
@@ -45,9 +45,9 @@
 /**
  * @brief  App初期化関数
  * @param  void
- * @return void
+ * @return RESULT
  */
-static void TLM_MGR_init_by_am_(void);
+static RESULT TLM_MGR_init_by_am_(void);
 
 /**
  * @brief  初期化（分割 1/2）
@@ -354,9 +354,10 @@ AppInfo TLM_MGR_create_app(void)
 }
 
 
-static void TLM_MGR_init_by_am_(void)
+static RESULT TLM_MGR_init_by_am_(void)
 {
   telemetry_manager_.is_inited = 0;
+  return RESULT_OK;
 }
 
 

--- a/Applications/timeline_command_dispatcher.c
+++ b/Applications/timeline_command_dispatcher.c
@@ -4,6 +4,7 @@
 #include "../System/TimeManager/time_manager.h"
 #include "../System/EventManager/event_logger.h"
 #include "../TlmCmd/common_cmd_packet_util.h"
+#include "../Library/result.h"
 
 #include <string.h> // for memset
 
@@ -11,15 +12,15 @@ static TimelineCommandDispatcher timeline_command_dispatcher_;
 const TimelineCommandDispatcher* const timeline_command_dispatcher = &timeline_command_dispatcher_;
 static CommonCmdPacket TLCD_null_packet_;
 
-static void TLCD_gs_init_(void);
-static void TLCD_gs_dispatch_(void);
-static void TLCD_bc_init_(void);
-static void TLCD_bc_dispatch_(void);
-static void TLCD_tlm_init_(void);
-static void TLCD_tlm_dispatch_(void);
+static RESULT TLCD_gs_init_(void);
+static RESULT TLCD_gs_dispatch_(void);
+static RESULT TLCD_bc_init_(void);
+static RESULT TLCD_bc_dispatch_(void);
+static RESULT TLCD_tlm_init_(void);
+static RESULT TLCD_tlm_dispatch_(void);
 #ifdef TLCD_ENABLE_MISSION_TL
-static void TLCD_mis_init_(void);
-static void TLCD_mis_dispatch_(void);
+static RESULT TLCD_mis_init_(void);
+static RESULT TLCD_mis_dispatch_(void);
 #endif
 
 /**
@@ -43,7 +44,7 @@ AppInfo TLCD_gs_create_app(void)
   return AI_create_app_info("tlcd_gs", TLCD_gs_init_, TLCD_gs_dispatch_);
 }
 
-static void TLCD_gs_init_(void)
+static RESULT TLCD_gs_init_(void)
 {
   timeline_command_dispatcher_.dispatcher[TLCD_ID_FROM_GS] = CDIS_init(&(PH_tl_cmd_list[TLCD_ID_FROM_GS]));
 
@@ -55,11 +56,13 @@ static void TLCD_gs_init_(void)
 
   memset(&TLCD_null_packet_, 0, sizeof(TLCD_null_packet_));
   TLCD_update_tl_list_for_tlm(TLCD_ID_FROM_GS);
+  return RESULT_OK;
 }
 
-static void TLCD_gs_dispatch_(void)
+static RESULT TLCD_gs_dispatch_(void)
 {
   TLCD_tlc_dispatcher_(TLCD_ID_FROM_GS);
+  return RESULT_OK;
 }
 
 AppInfo TLCD_bc_create_app(void)
@@ -67,14 +70,16 @@ AppInfo TLCD_bc_create_app(void)
   return AI_create_app_info("tlcd_bc", TLCD_bc_init_, TLCD_bc_dispatch_);
 }
 
-static void TLCD_bc_init_(void)
+static RESULT TLCD_bc_init_(void)
 {
   timeline_command_dispatcher_.dispatcher[TLCD_ID_DEPLOY_BC] = CDIS_init(&(PH_tl_cmd_list[TLCD_ID_DEPLOY_BC]));
+  return RESULT_OK;
 }
 
-static void TLCD_bc_dispatch_(void)
+static RESULT TLCD_bc_dispatch_(void)
 {
   TLCD_tlc_dispatcher_(TLCD_ID_DEPLOY_BC);
+  return RESULT_OK;
 }
 
 AppInfo TLCD_tlm_create_app(void)
@@ -82,14 +87,16 @@ AppInfo TLCD_tlm_create_app(void)
   return AI_create_app_info("tlcd_tlm", TLCD_tlm_init_, TLCD_tlm_dispatch_);
 }
 
-static void TLCD_tlm_init_(void)
+static RESULT TLCD_tlm_init_(void)
 {
   timeline_command_dispatcher_.dispatcher[TLCD_ID_DEPLOY_TLM] = CDIS_init(&(PH_tl_cmd_list[TLCD_ID_DEPLOY_TLM]));
+  return RESULT_OK;
 }
 
-static void TLCD_tlm_dispatch_(void)
+static RESULT TLCD_tlm_dispatch_(void)
 {
   TLCD_tlc_dispatcher_(TLCD_ID_DEPLOY_TLM);
+  return RESULT_OK;
 }
 
 #ifdef TLCD_ENABLE_MISSION_TL
@@ -98,14 +105,16 @@ AppInfo TLCD_mis_create_app(void)
   return AI_create_app_info("tlcd_mis", TLCD_mis_init_, TLCD_mis_dispatch_);
 }
 
-static void TLCD_mis_init_(void)
+static RESULT TLCD_mis_init_(void)
 {
   timeline_command_dispatcher_.dispatcher[TLCD_ID_FROM_GS_FOR_MISSION] = CDIS_init(&(PH_tl_cmd_list[TLCD_ID_FROM_GS_FOR_MISSION]));
+  return RESULT_OK;
 }
 
-static void TLCD_mis_dispatch_(void)
+static RESULT TLCD_mis_dispatch_(void)
 {
   TLCD_tlc_dispatcher_(TLCD_ID_FROM_GS_FOR_MISSION);
+  return RESULT_OK;
 }
 #endif
 

--- a/Applications/utility_command.c
+++ b/Applications/utility_command.c
@@ -5,12 +5,13 @@
 #include <src_user/Settings/port_config.h>
 #include <string.h>                     // for memcpy
 #include "../TlmCmd/common_cmd_packet_util.h"
+#include "../Library/result.h"
 
 
 static UtilityCommand utility_command_;
 const UtilityCommand* const utility_command = &utility_command_;
 
-static void UTIL_CMD_init_(void);
+static RESULT UTIL_CMD_init_(void);
 static void UTIL_CMD_reset_(void);
 static void UTIL_CMD_add_(unsigned char add_size, const unsigned char* cmd);
 static int UTIL_CMD_send_(unsigned char ch);
@@ -21,7 +22,7 @@ AppInfo UTIL_CMD_create_app(void)
   return AI_create_app_info("util_cmd", UTIL_CMD_init_, NULL);
 }
 
-static void UTIL_CMD_init_(void)
+static RESULT UTIL_CMD_init_(void)
 {
   int i;
   for (i = 0; i < UTIL_CMD_SIZE_MAX; i++)
@@ -37,6 +38,7 @@ static void UTIL_CMD_init_(void)
   utility_command_.uart_config_dummy.parity_settings = PARITY_SETTINGS_NONE;
   utility_command_.uart_config_dummy.data_length = UART_DATA_LENGTH_8BIT;
   utility_command_.uart_config_dummy.stop_bit = UART_STOP_BIT_1BIT;
+  return RESULT_OK;
 }
 
 static void UTIL_CMD_reset_(void)

--- a/Applications/utility_counter.c
+++ b/Applications/utility_counter.c
@@ -14,11 +14,12 @@ int UTIL_COUNTER_dummy(void)
 #include "../System/AnomalyLogger/anomaly_logger.h"
 #include <string.h>   // for memcpy
 #include "../TlmCmd/common_cmd_packet_util.h"
+#include "../Library/result.h"
 
 static UtilityCounter utility_counter_;
 const UtilityCounter* const utility_counter = &utility_counter_;
 
-static void UTIL_COUNTER_all_init_(void);
+static RESULT UTIL_COUNTER_all_init_(void);
 static void UTIL_COUNTER_clear_(UTIL_COUNTER_NAME num);
 static void UTIL_COUNTER_incl_(UTIL_COUNTER_NAME num);
 
@@ -28,7 +29,7 @@ AppInfo UTIL_COUNTER_create_app(void)
   return AI_create_app_info("utility_counter", UTIL_COUNTER_all_init_, NULL);
 }
 
-static void UTIL_COUNTER_all_init_(void)
+static RESULT UTIL_COUNTER_all_init_(void)
 {
   int i;
   for (i = 0; i < UTIL_COUNTER_MAX; i++)
@@ -37,6 +38,7 @@ static void UTIL_COUNTER_all_init_(void)
     utility_counter_.cnt[i].threshold = 0;
     utility_counter_.cnt[i].anomaly_active = 0;
   }
+  return RESULT_OK;
 }
 
 static void UTIL_COUNTER_clear_(UTIL_COUNTER_NAME num)

--- a/Examples/mobc/src/src_user/Applications/DriverInstances/di_aobc.c
+++ b/Examples/mobc/src/src_user/Applications/DriverInstances/di_aobc.c
@@ -12,12 +12,13 @@
 #include <src_core/TlmCmd/common_cmd_packet_util.h>
 #include "../../Settings/port_config.h"
 #include "../../Settings/DriverSuper/driver_buffer_define.h"
+#include <src_core/Library/result.h>
 
-static void DI_AOBC_init_(void);
-static void DI_AOBC_update_(void);
+static RESULT DI_AOBC_init_(void);
+static RESULT DI_AOBC_update_(void);
 
-static void DI_AOBC_cmd_dispatcher_init_(void);
-static void DI_AOBC_cmd_dispatcher_(void);
+static RESULT DI_AOBC_cmd_dispatcher_init_(void);
+static RESULT DI_AOBC_cmd_dispatcher_(void);
 
 static AOBC_Driver aobc_driver_;
 const AOBC_Driver* const aobc_driver = &aobc_driver_;
@@ -36,10 +37,11 @@ AppInfo DI_AOBC_update(void)
 }
 
 
-static void DI_AOBC_init_(void)
+static RESULT DI_AOBC_init_(void)
 {
   DS_ERR_CODE ret1;
   DS_INIT_ERR_CODE ret2;
+  RESULT err = RESULT_OK;
 
   ret1 = DS_init_stream_rec_buffer(&DI_AOBC_rx_buffer_,
                                    DI_AOBC_rx_buffer_allocation_,
@@ -47,17 +49,21 @@ static void DI_AOBC_init_(void)
   if (ret1 != DS_ERR_CODE_OK)
   {
     Printf("AOBC buffer init Failed ! %d \n", ret1);
+    err = RESULT_ERR;
   }
 
   ret2 = AOBC_init(&aobc_driver_, PORT_CH_RS422_AOBC, &DI_AOBC_rx_buffer_);
   if (ret2 != DS_INIT_OK)
   {
     Printf("AOBC init Failed ! %d \n", ret2);
+    err = RESULT_ERR;
   }
+
+  return err;
 }
 
 
-static void DI_AOBC_update_(void)
+static RESULT DI_AOBC_update_(void)
 {
   int ret;
   ret = AOBC_rec(&aobc_driver_);
@@ -65,6 +71,7 @@ static void DI_AOBC_update_(void)
   // [TODO]
   // 必要があればここに処理を
   (void)ret;
+  return RESULT_OK;
 }
 
 
@@ -76,15 +83,17 @@ AppInfo DI_AOBC_cmd_dispatcher(void)
 }
 
 
-static void DI_AOBC_cmd_dispatcher_init_(void)
+static RESULT DI_AOBC_cmd_dispatcher_init_(void)
 {
   DI_AOBC_cdis_ = CDIS_init(&PH_aobc_cmd_list);
+  return RESULT_OK;
 }
 
 
-static void DI_AOBC_cmd_dispatcher_(void)
+static RESULT DI_AOBC_cmd_dispatcher_(void)
 {
   CDIS_dispatch_command(&DI_AOBC_cdis_);
+  return RESULT_OK;
 }
 
 

--- a/Examples/mobc/src/src_user/Applications/DriverInstances/di_gs.c
+++ b/Examples/mobc/src/src_user/Applications/DriverInstances/di_gs.c
@@ -15,13 +15,13 @@
 static RESULT DI_GS_init_(void);
 
 // 以下 init と update の定義
-static void DI_GS_cmd_packet_handler_app_init_(void);
-static void DI_GS_cmd_packet_handler_app_(void);
+static RESULT DI_GS_cmd_packet_handler_app_init_(void);
+static RESULT DI_GS_cmd_packet_handler_app_(void);
 
-static void DI_GS_rt_tlm_packet_handler_app_init_(void);
-static void DI_GS_rt_tlm_packet_handler_app_(void);
-static void DI_GS_rp_tlm_packet_handler_app_init_(void);
-static void DI_GS_rp_tlm_packet_handler_app_(void);
+static RESULT DI_GS_rt_tlm_packet_handler_app_init_(void);
+static RESULT DI_GS_rt_tlm_packet_handler_app_(void);
+static RESULT DI_GS_rp_tlm_packet_handler_app_init_(void);
+static RESULT DI_GS_rp_tlm_packet_handler_app_(void);
 
 static void DI_GS_set_t2m_flush_interval_(cycle_t flush_interval, DI_GS_TlmPacketHandler* gs_tlm_packet_handler);
 
@@ -95,23 +95,26 @@ AppInfo DI_GS_rp_tlm_packet_handler_app(void)
   return AI_create_app_info("GS_RP_TLM", DI_GS_rp_tlm_packet_handler_app_init_, DI_GS_rp_tlm_packet_handler_app_);
 }
 
-static void DI_GS_cmd_packet_handler_app_init_(void)
+static RESULT DI_GS_cmd_packet_handler_app_init_(void)
 {
   DI_GS_init_();
+  return RESULT_OK;
 }
 
-static void DI_GS_cmd_packet_handler_app_(void)
+static RESULT DI_GS_cmd_packet_handler_app_(void)
 {
   GS_rec_tctf(&gs_driver_);
   // TODO: エラー処理
+  return RESULT_OK;
 }
 
-static void DI_GS_rt_tlm_packet_handler_app_init_(void)
+static RESULT DI_GS_rt_tlm_packet_handler_app_init_(void)
 {
   T2M_initialize(&DI_GS_rt_tlm_packet_handler_.tc_packet_to_m_pdu);
+  return RESULT_OK;
 }
 
-static void DI_GS_rt_tlm_packet_handler_app_(void)
+static RESULT DI_GS_rt_tlm_packet_handler_app_(void)
 {
   int i;
 
@@ -121,7 +124,7 @@ static void DI_GS_rt_tlm_packet_handler_app_(void)
     T2M_ACK ack = T2M_form_m_pdu(&DI_GS_rt_tlm_packet_handler_.tc_packet_to_m_pdu,
                                  &PH_rt_tlm_list,
                                  &DI_GS_rt_tlm_packet_handler_.vcdu.m_pdu);
-    if (ack != T2M_SUCCESS) return;
+    if (ack != T2M_SUCCESS) return RESULT_OK;
 
     // Realtime VCDU カウンタの設定
     VCDU_setup_realtime_vcdu_hdr(&DI_GS_rt_tlm_packet_handler_.vcdu, DI_GS_rt_tlm_packet_handler_.vcdu_counter);
@@ -136,14 +139,17 @@ static void DI_GS_rt_tlm_packet_handler_app_(void)
     // 完成した VCDU を RT VCDU として送出
     GS_send_vcdu(&gs_driver_, &DI_GS_rt_tlm_packet_handler_.vcdu);
   }
+
+  return RESULT_OK;
 }
 
-static void DI_GS_rp_tlm_packet_handler_app_init_(void)
+static RESULT DI_GS_rp_tlm_packet_handler_app_init_(void)
 {
   T2M_initialize(&DI_GS_rp_tlm_packet_handler_.tc_packet_to_m_pdu);
+  return RESULT_OK;
 }
 
-static void DI_GS_rp_tlm_packet_handler_app_(void)
+static RESULT DI_GS_rp_tlm_packet_handler_app_(void)
 {
   int i;
 
@@ -153,7 +159,7 @@ static void DI_GS_rp_tlm_packet_handler_app_(void)
     T2M_ACK ack = T2M_form_m_pdu(&DI_GS_rp_tlm_packet_handler_.tc_packet_to_m_pdu,
                                  &PH_rp_tlm_list,
                                  &DI_GS_rp_tlm_packet_handler_.vcdu.m_pdu);
-    if (ack != T2M_SUCCESS) return;
+    if (ack != T2M_SUCCESS) return RESULT_OK;
 
     // Replay VCDU カウンタの設定
     VCDU_setup_replay_vcdu_hdr(&DI_GS_rp_tlm_packet_handler_.vcdu, DI_GS_rp_tlm_packet_handler_.vcdu_counter);
@@ -168,6 +174,8 @@ static void DI_GS_rp_tlm_packet_handler_app_(void)
     // 完成した VCDU を RP VCDU として送出
     GS_send_vcdu(&gs_driver_, &DI_GS_rp_tlm_packet_handler_.vcdu);
   }
+
+  return RESULT_OK;
 }
 
 static void DI_GS_set_t2m_flush_interval_(cycle_t flush_interval, DI_GS_TlmPacketHandler* gs_tlm_packet_handler)

--- a/Examples/mobc/src/src_user/Applications/DriverInstances/di_uart_test.c
+++ b/Examples/mobc/src/src_user/Applications/DriverInstances/di_uart_test.c
@@ -9,10 +9,11 @@
 #include <src_core/TlmCmd/common_cmd_packet_util.h>
 #include "../../Settings/port_config.h"
 #include "../../Settings/DriverSuper/driver_buffer_define.h"
+#include <src_core/Library/result.h>
 
-static void UART_TEST_init_by_AM_(void);
+static RESULT UART_TEST_init_by_AM_(void);
 static void UART_TEST_init_(void);
-static void UART_TEST_update_(void);
+static RESULT UART_TEST_update_(void);
 // TODO: 実装する
 // static int  UART_TEST_fill_with_zero_(uint32_t no);
 // static int  UART_TEST_abort_fill_nodata_(uint8_t err);
@@ -39,9 +40,10 @@ AppInfo UART_TEST_update(void)
 }
 
 
-static void UART_TEST_init_by_AM_(void)
+static RESULT UART_TEST_init_by_AM_(void)
 {
   // ひとまず何もしない
+  return RESULT_OK;
 }
 
 
@@ -88,7 +90,7 @@ static void UART_TEST_init_(void)
 }
 
 
-static void UART_TEST_update_(void)
+static RESULT UART_TEST_update_(void)
 {
   DS_REC_ERR_CODE ret;
 
@@ -96,6 +98,7 @@ static void UART_TEST_update_(void)
 
   // TODO: エラー処理
   (void)ret;
+  return RESULT_OK;
 }
 
 

--- a/Examples/mobc/src/src_user/Applications/UserDefined/debug_apps.c
+++ b/Examples/mobc/src/src_user/Applications/UserDefined/debug_apps.c
@@ -21,14 +21,15 @@
 #include "../../Applications/DriverInstances/di_gs.h"
 // #include <src_core/TlmCmd/telemetry_generator.h>
 #include "../../Library/vt100.h"
+#include <src_core/Library/result.h>
 
-void APP_DBG_flush_screen_(void);
-void APP_DBG_print_time_stamp_(void);
-void APP_DBG_print_cmd_status_(void);
-void APP_DBG_print_event_logger0_(void);
-void APP_DBG_print_event_logger1_(void);
-void APP_DBG_print_event_handler_(void);
-void APP_DBG_print_git_rev_(void);
+static RESULT APP_DBG_flush_screen_(void);
+static RESULT APP_DBG_print_time_stamp_(void);
+static RESULT APP_DBG_print_cmd_status_(void);
+static RESULT APP_DBG_print_event_logger0_(void);
+static RESULT APP_DBG_print_event_logger1_(void);
+static RESULT APP_DBG_print_event_handler_(void);
+static RESULT APP_DBG_print_git_rev_(void);
 
 AppInfo APP_DBG_flush_screen(void)
 {
@@ -65,7 +66,7 @@ AppInfo APP_DBG_print_git_rev(void)
   return AI_create_app_info("debug_git_rev", NULL, APP_DBG_print_git_rev_);
 }
 
-void APP_DBG_flush_screen_(void)
+static RESULT APP_DBG_flush_screen_(void)
 {
   VT100_erase_down();
   VT100_reset_cursor();
@@ -73,9 +74,10 @@ void APP_DBG_flush_screen_(void)
   Printf("-- C2A SAMPLE Flight S/W (H-ON, F-ON) --\n");
   VT100_erase_line();
   Printf("BUILD: %s %s\n", __DATE__, __TIME__);
+  return RESULT_OK;
 }
 
-void APP_DBG_print_time_stamp_(void)
+static RESULT APP_DBG_print_time_stamp_(void)
 {
   VT100_erase_line();
   Printf("CYCLE: TOTAL %08d, MODE %08d\n",
@@ -83,9 +85,10 @@ void APP_DBG_print_time_stamp_(void)
   VT100_erase_line();
   Printf("MODE: STAT %d, PREV %d, CURR %d\n",
          mode_manager->stat, mode_manager->previous_id, mode_manager->current_id);
+  return RESULT_OK;
 }
 
-void APP_DBG_print_cmd_status_(void)
+static RESULT APP_DBG_print_cmd_status_(void)
 {
   VT100_erase_line();
   Printf("CMD: GS %3d, RT %3d, Ack %2d, ID 0x%02x, Sts %1d, EC %d\n",
@@ -95,9 +98,10 @@ void APP_DBG_print_cmd_status_(void)
          gs_command_dispatcher->prev.code,
          gs_command_dispatcher->prev.cmd_ret.exec_sts,
          gs_command_dispatcher->prev.cmd_ret.err_code);
+  return RESULT_OK;
 }
 
-void APP_DBG_print_event_logger0_(void)
+static RESULT APP_DBG_print_event_logger0_(void)
 {
 // 一旦めんどくさいので，以下の時のみ対応で書く
 #ifdef EL_IS_ENABLE_TLOG
@@ -122,9 +126,10 @@ void APP_DBG_print_event_logger0_(void)
 #endif
 #endif
 #endif
+  return RESULT_OK;
 }
 
-void APP_DBG_print_event_logger1_(void)
+static RESULT APP_DBG_print_event_logger1_(void)
 {
 // 一旦めんどくさいので，以下の時のみ対応で書く
 #ifdef EL_IS_ENABLE_TLOG
@@ -146,9 +151,10 @@ void APP_DBG_print_event_logger1_(void)
 #endif
 #endif
 #endif
+  return RESULT_OK;
 }
 
-void APP_DBG_print_event_handler_(void)
+static RESULT APP_DBG_print_event_handler_(void)
 {
   const EH_Log* latest = EH_get_the_nth_log_from_the_latest(0);
   const EH_Log* second = EH_get_the_nth_log_from_the_latest(1);
@@ -159,13 +165,15 @@ void APP_DBG_print_event_handler_(void)
          latest->respond_time_in_master_cycle,
          second->rule_id,
          second->respond_time_in_master_cycle);
+  return RESULT_OK;
 }
 
-void APP_DBG_print_git_rev_(void)
+static RESULT APP_DBG_print_git_rev_(void)
 {
   VT100_erase_line();
   Printf("Git rev: CORE 0x%07x, USER 0x%07x\n",
          GIT_REV_CORE_SHORT, GIT_REV_USER_SHORT);
+  return RESULT_OK;
 }
 
 #pragma section

--- a/Examples/subobc/src/src_user/Applications/UserDefined/debug_apps.c
+++ b/Examples/subobc/src/src_user/Applications/UserDefined/debug_apps.c
@@ -21,14 +21,15 @@
 #include "../../Applications/DriverInstances/di_mobc.h"
 // #include <src_core/TlmCmd/telemetry_generator.h>
 #include "../../Library/vt100.h"
+#include <src_core/Library/result.h>
 
-void APP_DBG_flush_screen_(void);
-void APP_DBG_print_time_stamp_(void);
-void APP_DBG_print_cmd_status_(void);
-void APP_DBG_print_event_logger0_(void);
-void APP_DBG_print_event_logger1_(void);
-void APP_DBG_print_event_handler_(void);
-void APP_DBG_print_git_rev_(void);
+static RESULT APP_DBG_flush_screen_(void);
+static RESULT APP_DBG_print_time_stamp_(void);
+static RESULT APP_DBG_print_cmd_status_(void);
+static RESULT APP_DBG_print_event_logger0_(void);
+static RESULT APP_DBG_print_event_logger1_(void);
+static RESULT APP_DBG_print_event_handler_(void);
+static RESULT APP_DBG_print_git_rev_(void);
 
 AppInfo APP_DBG_flush_screen(void)
 {
@@ -65,7 +66,7 @@ AppInfo APP_DBG_print_git_rev(void)
   return AI_create_app_info("debug_git_rev", NULL, APP_DBG_print_git_rev_);
 }
 
-void APP_DBG_flush_screen_(void)
+static RESULT APP_DBG_flush_screen_(void)
 {
   VT100_erase_down();
   VT100_reset_cursor();
@@ -73,9 +74,10 @@ void APP_DBG_flush_screen_(void)
   Printf("-- C2A SUBOBC SAMPLE Flight S/W --\n");
   VT100_erase_line();
   Printf("BUILD: %s %s\n", __DATE__, __TIME__);
+  return RESULT_OK;
 }
 
-void APP_DBG_print_time_stamp_(void)
+static RESULT APP_DBG_print_time_stamp_(void)
 {
   VT100_erase_line();
   Printf("CYCLE: TOTAL %08d, MODE %08d\n",
@@ -83,9 +85,10 @@ void APP_DBG_print_time_stamp_(void)
   VT100_erase_line();
   Printf("MODE: STAT %d, PREV %d, CURR %d\n",
          mode_manager->stat, mode_manager->previous_id, mode_manager->current_id);
+  return RESULT_OK;
 }
 
-void APP_DBG_print_cmd_status_(void)
+static RESULT APP_DBG_print_cmd_status_(void)
 {
   VT100_erase_line();
   Printf("CMD: GS %3d, RT %3d, Ack %2d, ID 0x%02x, Sts %1d, EC %d\n",
@@ -95,9 +98,10 @@ void APP_DBG_print_cmd_status_(void)
          gs_command_dispatcher->prev.code,
          gs_command_dispatcher->prev.cmd_ret.exec_sts,
          gs_command_dispatcher->prev.cmd_ret.err_code);
+  return RESULT_OK;
 }
 
-void APP_DBG_print_event_logger0_(void)
+static RESULT APP_DBG_print_event_logger0_(void)
 {
 // 一旦めんどくさいので，以下の時のみ対応で書く
 #ifdef EL_IS_ENABLE_TLOG
@@ -122,9 +126,10 @@ void APP_DBG_print_event_logger0_(void)
 #endif
 #endif
 #endif
+  return RESULT_OK;
 }
 
-void APP_DBG_print_event_logger1_(void)
+static RESULT APP_DBG_print_event_logger1_(void)
 {
 // 一旦めんどくさいので，以下の時のみ対応で書く
 #ifdef EL_IS_ENABLE_TLOG
@@ -146,9 +151,10 @@ void APP_DBG_print_event_logger1_(void)
 #endif
 #endif
 #endif
+  return RESULT_OK;
 }
 
-void APP_DBG_print_event_handler_(void)
+static RESULT APP_DBG_print_event_handler_(void)
 {
   const EH_Log* latest = EH_get_the_nth_log_from_the_latest(0);
   const EH_Log* second = EH_get_the_nth_log_from_the_latest(1);
@@ -159,13 +165,15 @@ void APP_DBG_print_event_handler_(void)
          latest->respond_time_in_master_cycle,
          second->rule_id,
          second->respond_time_in_master_cycle);
+  return RESULT_OK;
 }
 
-void APP_DBG_print_git_rev_(void)
+static RESULT APP_DBG_print_git_rev_(void)
 {
   VT100_erase_line();
   Printf("Git rev: CORE 0x%07x, USER 0x%07x\n",
          GIT_REV_CORE_SHORT, GIT_REV_USER_SHORT);
+  return RESULT_OK;
 }
 
 #pragma section

--- a/System/ApplicationManager/app_info.c
+++ b/System/ApplicationManager/app_info.c
@@ -7,8 +7,8 @@
 #include <stddef.h>
 
 AppInfo AI_create_app_info(const char* name,
-                           void (*initializer)(void),
-                           void (*entry_point)(void))
+                           RESULT (*initializer)(void),
+                           RESULT (*entry_point)(void))
 {
   AppInfo ai;
 

--- a/System/ApplicationManager/app_info.c
+++ b/System/ApplicationManager/app_info.c
@@ -23,4 +23,11 @@ AppInfo AI_create_app_info(const char* name,
   return ai;
 }
 
+void AI_clear_app_exec_time(AppInfo* ai)
+{
+  ai->prev = 0;
+  ai->max = 0;
+  ai->min = 0xffffffff;
+}
+
 #pragma section

--- a/System/ApplicationManager/app_info.h
+++ b/System/ApplicationManager/app_info.h
@@ -30,4 +30,11 @@ AppInfo AI_create_app_info(const char* name,
                            RESULT (*initializer)(void),
                            RESULT (*entry_point)(void));
 
+/**
+ * @brief  AppInfo から，アプリ実行時間をクリアする
+ * @param  ai: AppInfo
+ * @return void
+ */
+void AI_clear_app_exec_time(AppInfo* ai);
+
 #endif

--- a/System/ApplicationManager/app_info.h
+++ b/System/ApplicationManager/app_info.h
@@ -6,16 +6,17 @@
 #define APP_INFO_H_
 
 #include "../TimeManager/obc_time.h"
+#include "../../Library/result.h"
 
 typedef struct
 {
-  const char* name;           //!< アプリ名 (C2A 内部では使用されていない )
-  step_t init_duration;       //!< アプリ初期化処理時間
-  step_t prev;                //!< アプリ実行処理時間（直近）
-  step_t min;                 //!< アプリ実行処理時間（最小値）
-  step_t max;                 //!< アプリ実行処理時間（最大値）
-  void (*initializer)(void);  //!< アプリ初期化関数
-  void (*entry_point)(void);  //!< アプリ実行関数（エントリーポイント）
+  const char* name;             //!< アプリ名 (C2A 内部では使用されていない )
+  step_t init_duration;         //!< アプリ初期化処理時間
+  step_t prev;                  //!< アプリ実行処理時間（直近）
+  step_t min;                   //!< アプリ実行処理時間（最小値）
+  step_t max;                   //!< アプリ実行処理時間（最大値）
+  RESULT (*initializer)(void);  //!< アプリ初期化関数
+  RESULT (*entry_point)(void);  //!< アプリ実行関数（エントリーポイント）
 } AppInfo;
 
 /**
@@ -26,7 +27,7 @@ typedef struct
  * @return 作成された AppInfo
  */
 AppInfo AI_create_app_info(const char* name,
-                           void (*initializer)(void),
-                           void (*entry_point)(void));
+                           RESULT (*initializer)(void),
+                           RESULT (*entry_point)(void));
 
 #endif

--- a/System/ApplicationManager/app_manager.h
+++ b/System/ApplicationManager/app_manager.h
@@ -1,8 +1,12 @@
+/**
+ * @file
+ * @brief Application Manager
+ * @note  C2A の App を管理する
+ */
 #ifndef APP_MANAGER_H_
 #define APP_MANAGER_H_
 
-#include <stddef.h> // for size_t
-
+#include <stddef.h>
 #include "app_info.h"
 #include "../../TlmCmd/common_cmd_packet.h"
 
@@ -12,26 +16,53 @@
 
 #include <src_user/Settings/System/app_manager_params.h>
 
+/**
+ * @struct AppManager
+ * @brief  AppManager の Info 構造体
+ */
 typedef struct
 {
   AppInfo ais[AM_MAX_APPS];
   int page_no;
 } AppManager;
 
+/**
+ * @enum   AM_ACK
+ * @note   uint8_t を想定
+ * @brief  AM エラーコード
+ */
 typedef enum
 {
   AM_SUCCESS,
   AM_INVALID_ID,
-  AM_NOT_REGISTERED
+  AM_NOT_REGISTERED,
+  AM_INIT_FAILED,
+  AM_EXEC_FAILED
 } AM_ACK;
 
 extern const AppManager* const app_manager;
 
+/**
+ * @brief  App Manager の初期化
+ * @param  void
+ * @return void
+ */
 void AM_initialize(void);
 
-AM_ACK AM_register_ai(size_t id,
-                      const AppInfo* ai);
+/**
+ * @brief  AM に App を登録する
+ * @param  id: 登録する App の ID
+ * @param  ai: 登録する App の AppInfo
+ * @retval AM_SUCCESS: 成功
+ * @retval AM_INVALID_ID: ID の不正
+ */
+AM_ACK AM_register_ai(size_t id, const AppInfo* ai);
 
+/**
+ * @brief  AM に登録されたすべての App を初期化する
+ * @param  void
+ * @return void
+ */
 void AM_initialize_all_apps(void);
 
 CCP_CmdRet Cmd_AM_REGISTER_APP(const CommonCmdPacket* packet);


### PR DESCRIPTION
## 概要
App の initializer, entry_point の返り値を void から RESULT にする

## Issue
- https://github.com/arkedge/c2a-core/issues/17

## 詳細
App の初期化，実行のエラーをAMに通知する方法を追加

## 検証結果
全てのテストが通った

## 影響範囲
user の App の initializer, entry_point を修正する必要がある

## 補足
- [x] https://github.com/arkedge/c2a-core/pull/16 を先にマージする

<!--
## 注意
- 関連する Projects が存在する場合，それの紐付けを行うこと
- Assignees を設定すること
- 可能ならば Reviewers を設定すること
- 可能ならば `priority` ラベルを付けること
-->
