### PR TITLE
Make c2a-core repository as cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,15 @@
+[workspace.package]
+version = "3.10.0"
+
+[workspace]
+resolver = "2"
+
+members = [
+]
+
 [package]
 name = "c2a-core"
-version = "3.10.0"
+version.workspace = true
 edition = "2021"
 
 links = "c2a-core"

--- a/docs/general/release.md
+++ b/docs/general/release.md
@@ -19,7 +19,7 @@
 
 1. バージョン番号をインクリメントする PR (Pull Request) を発行し，`develop` ブランチへマージする．
     - [c2a_core_main.h](https://github.com/arkedge/c2a-core/blob/develop/c2a_core_main.h) 内の `C2A_CORE_VER_*` をインクリメントする．
-    - [Cargo.toml](https://github.com/arkedge/c2a-core/blob/develop/Cargo.toml) 内の `package.version` をインクリメントする．
+    - [Cargo.toml](https://github.com/arkedge/c2a-core/blob/develop/Cargo.toml) 内の `workspace.package.version` をインクリメントする．
     - この後リリースを控えるので，念の為すべてのテストを再度回す．
     - `#define C2A_CORE_VER_PRE` は `("")` とする．
     - PR 名は `Update version (v3.4.0)` のようにする．


### PR DESCRIPTION
## 概要
cargo workspace にする

## Issue
- #2 

## 詳細
今後 `c2a-core` crate 以外の crate がこのリポジトリに導入されるため，cargo workspace にする

## 影響範囲
`c2a-core` crate など Rust 部分

## 補足
resolver 2 を明示的に指定しているのは，https://github.com/rust-lang/cargo/issues/5730 のような問題が発生する可能性があり，また， resolver 2 は opt-in であるため: https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html#details