### PR TITLE
Extern System functions for SILS runtime

### DIFF
--- a/System/mod.rs
+++ b/System/mod.rs
@@ -1,4 +1,4 @@
-#[doc = "watchdog_timer.h が単体で bindgen 不可能だったので自前定義したもの"]
+#[doc = "FIXME: watchdog_timer.h が単体で bindgen 不可能だったので自前定義したもの"]
 pub mod WatchdogTimer {
     extern "C" {
         pub fn WDT_init();
@@ -7,7 +7,7 @@ pub mod WatchdogTimer {
     }
 }
 
-#[doc = "time_manager.h が単体で bindgen 不可能だったので自前定義したもの"]
+#[doc = "FIXME: time_manager.h が単体で bindgen 不可能だったので自前定義したもの"]
 pub mod TimeManager {
     extern "C" {
         pub fn TMGR_init();

--- a/System/mod.rs
+++ b/System/mod.rs
@@ -1,0 +1,19 @@
+#[doc = "watchdog_timer.h が単体で bindgen 不可能だったので自前定義したもの"]
+pub mod WatchdogTimer {
+    extern "C" {
+        pub fn WDT_init();
+
+        pub fn WDT_clear_wdt();
+    }
+}
+
+#[doc = "time_manager.h が単体で bindgen 不可能だったので自前定義したもの"]
+pub mod TimeManager {
+    extern "C" {
+        pub fn TMGR_init();
+
+        pub fn TMGR_clear();
+
+        pub fn TMGR_count_up_master_clock();
+    }
+}

--- a/c2a_core.rs
+++ b/c2a_core.rs
@@ -7,6 +7,7 @@
 use core::*;
 include!(concat!(env!("OUT_DIR"), "/c2a_core_main.rs"));
 
+pub mod System;
 pub mod hal;
 
 #[cfg(feature = "export-src")]


### PR DESCRIPTION
## 概要
SILS runtime で用いる `System/` 以下の関数を（bindgen の代わりに手動で）Rust から扱えるようにする

## Issue
- #2 
- #14 

## 詳細
#14 がまだなので，`System/` 以下の関数のプロトタイプ宣言が含まれたヘッダ（例: `watchdog_timer.h`）が bindgen できない．そこで，SILS runtime で使う必要最低限の関数だけ手動で extern 宣言しておく．

## 影響範囲
`c2a-core` crate