### PR TITLE
Introduce c2a-sils-runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,12 @@ version = "3.10.0"
 resolver = "2"
 
 members = [
+  "./sils-runtime",
   "./Library/bind-utils",
 ]
+
+[workspace.dependencies]
+c2a-core = { path = "." }
 
 [package]
 name = "c2a-core"

--- a/sils-runtime/Cargo.toml
+++ b/sils-runtime/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "c2a-sils-runtime"
+description = "common C2A runtime for SILS"
+version.workspace = true
+edition = "2021"
+
+[lib]
+test = false   # 呼んでいる C2A の関数をリンクできないので，unit test はしない（できない）
+# TODO: 適切な c2a-core とマッチした example user をリンクしたテスト
+
+[dependencies]
+c2a-core.workspace = true

--- a/sils-runtime/src/lib.rs
+++ b/sils-runtime/src/lib.rs
@@ -1,0 +1,43 @@
+use std::{thread, time};
+
+const UPDATE_BATCH_SIZE: usize = 100;
+const UPDATE_BATCH_IN_REALTIME: time::Duration = time::Duration::from_millis(100);
+
+pub fn c2a_init() {
+    use c2a_core::*;
+
+    unsafe {
+        System::WatchdogTimer::WDT_init();
+        System::TimeManager::TMGR_init(); // Time Manager
+    }
+
+    unsafe {
+        C2A_core_init();
+    }
+
+    // TaskDispatcherでの大量のアノマリを避けるために、一度時刻を初期化する。
+    unsafe {
+        System::TimeManager::TMGR_clear();
+    }
+    println!("C2A_init: TMGR_init done.");
+}
+
+pub fn c2a_main() {
+    use c2a_core::*;
+
+    loop {
+        let start = time::Instant::now();
+        for _ in 0..UPDATE_BATCH_SIZE {
+            unsafe {
+                System::TimeManager::TMGR_count_up_master_clock();
+                C2A_core_main();
+            }
+        }
+        let elapsed_time = start.elapsed();
+        if elapsed_time < UPDATE_BATCH_IN_REALTIME {
+            let duration_to_sleep = UPDATE_BATCH_IN_REALTIME - elapsed_time;
+            thread::sleep(duration_to_sleep);
+        }
+        // 時間がめっちゃ遅れてたときの時間回復は一旦しない
+    }
+}

--- a/sils-runtime/src/lib.rs
+++ b/sils-runtime/src/lib.rs
@@ -38,6 +38,6 @@ pub fn c2a_main() {
             let duration_to_sleep = UPDATE_BATCH_IN_REALTIME - elapsed_time;
             thread::sleep(duration_to_sleep);
         }
-        // 時間がめっちゃ遅れてたときの時間回復は一旦しない
+        // FIXME: 時間がめっちゃ遅れてたときの時間回復は一旦しない
     }
 }


### PR DESCRIPTION
## 概要
SILS 向けの共通 C2A runtime 実装（`c2a-sils-runtime` crate）を追加します

## Issue
- #2 

## 詳細
`c2a-sils-runtime` 内で使う関数は一旦 #37 を経由して呼んでいます