### PR TITLE
Run examples/subobc on c2a-sils-runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,16 @@ members = [
   "./hal/wdt-noop",
 
   "./hal/uart-kble",
+
+  "./examples/subobc",
 ]
 
 [workspace.dependencies]
 c2a-core = { path = "." }
+
+c2a-sils-runtime = { path = "./sils-runtime" }
+c2a-wdt-noop = { path = "./hal/wdt-noop" }
+c2a-uart-kble = { path = "./hal/uart-kble" }
 
 [package]
 name = "c2a-core"

--- a/examples/subobc/Cargo.toml
+++ b/examples/subobc/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "c2a-example-subobc"
+version.workspace = true
+edition = "2021"
+
+[dependencies]
+c2a-core.workspace = true
+
+# runtime
+c2a-sils-runtime.workspace = true
+
+# ifimpl
+c2a-uart-kble.workspace = true
+c2a-wdt-noop.workspace = true
+
+[build-dependencies]
+cmake = "0.1"

--- a/examples/subobc/build.rs
+++ b/examples/subobc/build.rs
@@ -1,0 +1,22 @@
+fn main() {
+    // Build C2A & link
+    let mut c2a_cmake = cmake::Config::new(".");
+    let libc2a = c2a_cmake
+        .very_verbose(true)
+        .define("USE_32BIT_COMPILER", "ON")
+        .define("BUILD_C2A_AS_C99", "ON")
+        .define("BUILD_C2A_AS_SILS_FW", "ON")
+        .define("USE_SCI_COM_WINGS", "OFF")
+        .build_target("C2A");
+
+    println!("cargo:rerun-if-changed=./CMakeLists.txt");
+    println!("cargo:rerun-if-changed=./src/src_core");
+    println!("cargo:rerun-if-changed=./src/src_user");
+
+    let libc2a = libc2a.build();
+    println!(
+        "cargo:rustc-link-search=native={}/build", // no install step in libC2A
+        libc2a.display()
+    );
+    println!("cargo:rustc-link-lib=static=C2A");
+}

--- a/examples/subobc/src/main.rs
+++ b/examples/subobc/src/main.rs
@@ -1,0 +1,9 @@
+use c2a_sils_runtime as c2a_runtime;
+
+extern crate c2a_uart_kble;
+extern crate c2a_wdt_noop;
+
+fn main() {
+    c2a_runtime::c2a_init();
+    c2a_runtime::c2a_main();
+}


### PR DESCRIPTION
## 概要
`examples/subobc` を c2a-sils-runtime に載せて動作可能にします

## Issue / PR
- #2 
- #38 
- #40 
- #41 

## 詳細
"c2a-runtime" と呼ばれている，C2A を Rust 製の runtime（ここでは `c2a-sils-runtime`）に載せ，ハードウェア抽象化レイヤ（`c2a-hal`）を Rust で実装可能にし，Cargo で一撃でビルド・単体動作（S2E 不要の SILS）可能にするものを `examples/subobc` に導入します．

また，UART のエミュレーションに `c2a-uart-kble` を用いているため，テレコマ接続を [kble](https://github.com/arkedge/kble) 経由で引き回すことが可能です．

- runtime: `c2a-sils-runtime`
- HAL impl
  - `c2a-uart-kble`
  - `c2a-wdt-noop`

## 検証結果
`cargo run -p c2a-example-subobc`
![2023-08-02_16-11](https://github.com/arkedge/c2a-core/assets/23310673/258c6e16-ebda-4ce5-acb5-1ac2b3ef4bd0)

## 影響範囲
OSS 版 c2a-core subobc example が `cargo run` できるようになる