### PR TITLE
Run examples/mobc on c2a-sils-runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ members = [
 
   "./hal/uart-kble",
 
+  "./examples/mobc",
   "./examples/subobc",
 ]
 
 [workspace.dependencies]
 c2a-core = { path = "." }
+c2a-bind-utils = { path = "./Library/bind-utils", version = "3.10" }    # TODO: release
 
 c2a-sils-runtime = { path = "./sils-runtime" }
 c2a-wdt-noop = { path = "./hal/wdt-noop" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 
 [workspace.dependencies]
 c2a-core = { path = "." }
-c2a-bind-utils = { path = "./Library/bind-utils", version = "3.10" }    # TODO: release
+c2a-bind-utils = { path = "./Library/bind-utils" }
 
 c2a-sils-runtime = { path = "./sils-runtime" }
 c2a-wdt-noop = { path = "./hal/wdt-noop" }

--- a/examples/mobc/Cargo.toml
+++ b/examples/mobc/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "c2a-example-mobc"
+version.workspace = true
+edition = "2021"
+
+[dependencies]
+c2a-core.workspace = true
+
+# runtime
+c2a-sils-runtime.workspace = true
+
+# c2a-hal impl
+c2a-example-mobc-ccsds-kble = { path = "./src/src_user/hal/ccsds-kble" }
+c2a-uart-kble.workspace = true
+c2a-wdt-noop.workspace = true
+
+[build-dependencies]
+cmake = "0.1"

--- a/examples/mobc/build.rs
+++ b/examples/mobc/build.rs
@@ -1,0 +1,21 @@
+fn main() {
+    // Build C2A & link
+    let mut c2a_cmake = cmake::Config::new(".");
+    let libc2a = c2a_cmake
+        .very_verbose(true)
+        .define("USE_32BIT_COMPILER", "ON")
+        .define("BUILD_C2A_AS_C99", "ON")
+        .define("BUILD_C2A_AS_SILS_FW", "ON")
+        .define("USE_SCI_COM_WINGS", "OFF")
+        .build_target("C2A");
+
+    println!("cargo:rerun-if-changed=./src/src_core");
+    println!("cargo:rerun-if-changed=./src/src_user");
+
+    let libc2a = libc2a.build();
+    println!(
+        "cargo:rustc-link-search=native={}/build", // no install step in libC2A
+        libc2a.display()
+    );
+    println!("cargo:rustc-link-lib=static=C2A");
+}

--- a/examples/mobc/src/main.rs
+++ b/examples/mobc/src/main.rs
@@ -1,0 +1,10 @@
+use c2a_sils_runtime as c2a_runtime;
+
+extern crate c2a_example_mobc_ccsds_kble;
+extern crate c2a_uart_kble;
+extern crate c2a_wdt_noop;
+
+fn main() {
+    c2a_runtime::c2a_init();
+    c2a_runtime::c2a_main();
+}

--- a/examples/mobc/src/src_user/hal/ccsds-kble/Cargo.toml
+++ b/examples/mobc/src/src_user/hal/ccsds-kble/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "c2a-example-mobc-ccsds-kble"
+description = "kble-based CCSDS emulation for examples/mobc"
+version.workspace = true
+edition = "2021"
+
+[dependencies]
+c2a-core.workspace = true
+anyhow = "1"
+futures = "0.3"
+kble-socket = { version = "0.2.0", features = ["tungstenite"] }
+tokio-tungstenite = "0.18"
+tokio = { version = "1", features = ["sync", "rt"] }
+once_cell = "1"
+
+[build-dependencies]
+c2a-bind-utils.workspace = true

--- a/examples/mobc/src/src_user/hal/ccsds-kble/build.rs
+++ b/examples/mobc/src/src_user/hal/ccsds-kble/build.rs
@@ -1,0 +1,18 @@
+use std::env;
+use std::path::PathBuf;
+
+use c2a_bind_utils::*;
+
+fn main() {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    let bind = bind_c2a_builder()
+        .header("../ccsds_user.h")
+        .clang_arg("-I../../../")
+        .generate()
+        .expect("Unable to generate bindings!");
+    bind.write_to_file(out_dir.join("ccsds_user.rs"))
+        .expect("Couldn't write bindings!");
+
+    println!("cargo:rerun-if-changed=../ccsds_user.h");
+}

--- a/examples/mobc/src/src_user/hal/ccsds-kble/src/ccsds_user.rs
+++ b/examples/mobc/src/src_user/hal/ccsds-kble/src/ccsds_user.rs
@@ -1,0 +1,24 @@
+use std::os::raw::c_void;
+
+use c2a_core::hal::ccsds::CCSDS_Config;
+
+use crate::ccsds_user_bind::{CCSDS_ERR_CODE, CCSDS_ERR_CODE_CCSDS_ERR_OK};
+
+#[no_mangle]
+pub extern "C" fn CCSDS_read_sequence(_select: u32, _uip_stat: *const u32) -> CCSDS_ERR_CODE {
+    CCSDS_ERR_CODE_CCSDS_ERR_OK
+}
+
+#[no_mangle]
+pub extern "C" fn CCSDS_get_buffer_num() -> u8 {
+    8
+}
+
+#[no_mangle]
+pub extern "C" fn CCSDS_set_rate(ui_rate: u32, config: *mut c_void) {
+    let ui_rate = if ui_rate > 0xFF { 0xFF } else { ui_rate };
+
+    let config = config as *mut CCSDS_Config;
+    let config = unsafe { &mut *config };
+    config.bitrate = 40000000 / ui_rate; // [bps]
+}

--- a/examples/mobc/src/src_user/hal/ccsds-kble/src/ccsds_user_bind.rs
+++ b/examples/mobc/src/src_user/hal/ccsds-kble/src/ccsds_user_bind.rs
@@ -1,0 +1,7 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+
+use core::*;
+include!(concat!(env!("OUT_DIR"), "/ccsds_user.rs"));

--- a/examples/mobc/src/src_user/hal/ccsds-kble/src/kble.rs
+++ b/examples/mobc/src/src_user/hal/ccsds-kble/src/kble.rs
@@ -1,0 +1,64 @@
+use std::thread;
+
+use anyhow::{anyhow, Result};
+use futures::{future, SinkExt, TryStreamExt};
+use tokio::{
+    net::{TcpListener, ToSocketAddrs},
+    sync::mpsc,
+};
+
+pub fn new() -> (mpsc::Sender<Vec<u8>>, mpsc::Receiver<Vec<u8>>, Socket) {
+    let (tlm_tx, tlm_rx) = mpsc::channel(5);
+    let (cmd_tx, cmd_rx) = mpsc::channel(5);
+    let socket = Socket { tlm_rx, cmd_tx };
+    (tlm_tx, cmd_rx, socket)
+}
+
+pub struct Socket {
+    tlm_rx: mpsc::Receiver<Vec<u8>>,
+    cmd_tx: mpsc::Sender<Vec<u8>>,
+}
+
+impl Socket {
+    pub async fn serve(mut self, addr: impl ToSocketAddrs) -> Result<()> {
+        let listener = TcpListener::bind(addr).await?;
+        loop {
+            let (incoming, _addr) = listener.accept().await?;
+            let wss = tokio_tungstenite::accept_async(incoming).await?;
+            let (mut sink, mut stream) = kble_socket::from_tungstenite(wss);
+            let uplink = async {
+                loop {
+                    let tlm_bytes = self
+                        .tlm_rx
+                        .recv()
+                        .await
+                        .ok_or_else(|| anyhow!("telemetry producer has gone"))?;
+                    sink.send(tlm_bytes.into()).await?;
+                }
+            };
+            let downlink = async {
+                loop {
+                    let Some(cmd_bytes) = stream.try_next().await? else {
+                        break;
+                    };
+                    self.cmd_tx.send(cmd_bytes.into()).await?;
+                }
+                anyhow::Ok(())
+            };
+            let _: Option<((), ())> = future::try_join(uplink, downlink).await.ok();
+        }
+    }
+
+    pub fn serve_in_background(self, addr: impl ToSocketAddrs + Send + 'static) {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        thread::spawn(move || {
+            let fut = self.serve(addr);
+            if let Err(e) = rt.block_on(fut) {
+                eprintln!("kble server has exited: {e}");
+            }
+        });
+    }
+}

--- a/examples/mobc/src/src_user/hal/ccsds-kble/src/lib.rs
+++ b/examples/mobc/src/src_user/hal/ccsds-kble/src/lib.rs
@@ -1,0 +1,77 @@
+pub mod ccsds_user;
+pub mod ccsds_user_bind;
+
+mod kble;
+
+use ccsds_user_bind::{
+    CCSDS_ERR_CODE_CCSDS_ERR_OK, CCSDS_ERR_CODE_CCSDS_ERR_RX_4KBPS,
+    CCSDS_ERR_CODE_CCSDS_ERR_TX_INVALID,
+};
+
+use once_cell::sync::Lazy;
+use tokio::sync::mpsc::{self, error::TryRecvError};
+
+use std::{
+    os::raw::{c_int, c_void},
+    sync::Mutex,
+};
+
+struct KblePair {
+    tlm_tx: mpsc::Sender<Vec<u8>>,
+    cmd_rx: Mutex<mpsc::Receiver<Vec<u8>>>,
+}
+
+static KBLE: Lazy<KblePair> = Lazy::new(|| {
+    let (tlm_tx, cmd_rx, socket) = kble::new();
+    let cmd_rx = Mutex::new(cmd_rx);
+    let kble_addr = std::env::var("IF_CCSDS_KBLE_ADDR");
+    let kble_addr = kble_addr.unwrap_or("0.0.0.0:22545".to_string());
+    socket.serve_in_background(kble_addr);
+    KblePair { tlm_tx, cmd_rx }
+});
+
+#[no_mangle]
+pub extern "C" fn CCSDS_init(my_ccsds_v: *mut c_void) -> c_int {
+    ccsds_user::CCSDS_set_rate(0xAD, my_ccsds_v); // 初期値 230.4 [kbps]
+    Lazy::force(&KBLE);
+    CCSDS_ERR_CODE_CCSDS_ERR_OK.0
+}
+
+#[no_mangle]
+pub extern "C" fn CCSDS_rx(
+    _my_ccsds_v: *mut c_void,
+    data_v: *mut c_void,
+    buffer_size: c_int,
+) -> c_int {
+    let cmd_bytes = match KBLE.cmd_rx.lock().unwrap().try_recv() {
+        Ok(cmd_bytes) => cmd_bytes,
+        Err(TryRecvError::Empty) => return 0,
+        _ => return CCSDS_ERR_CODE_CCSDS_ERR_RX_4KBPS.0,
+    };
+    let buf = unsafe { std::slice::from_raw_parts_mut(data_v as *mut u8, buffer_size as usize) };
+    if cmd_bytes.len() > buf.len() {
+        // buffer is too short
+        return CCSDS_ERR_CODE_CCSDS_ERR_RX_4KBPS.0;
+    }
+    let len = cmd_bytes.len();
+    buf[..len].copy_from_slice(&cmd_bytes[..]);
+    len as c_int
+}
+
+#[no_mangle]
+pub extern "C" fn CCSDS_tx(
+    _my_ccsds_v: *mut c_void,
+    data_v: *mut c_void,
+    data_size: c_int,
+) -> c_int {
+    let buf = unsafe { std::slice::from_raw_parts(data_v as *const u8, data_size as usize) };
+    match KBLE.tlm_tx.try_send(buf.to_vec()) {
+        Ok(_) => CCSDS_ERR_CODE_CCSDS_ERR_OK.0,
+        Err(_) => CCSDS_ERR_CODE_CCSDS_ERR_TX_INVALID.0,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn CCSDS_reopen(_my_ccsds_v: *mut c_void, _reson: c_int) -> c_int {
+    CCSDS_ERR_CODE_CCSDS_ERR_OK.0
+}


### PR DESCRIPTION
## 概要
`examples/mobc` を `c2a-sils-runtime` に載せて動作可能にします

## Issue / PR
- #2 
- #38 
- #40 
- #41 

## 詳細
#44 と同様に，"c2a-runtime" と呼ばれている，C2A を Rust 製の runtime（ここでは `c2a-sils-runtime`）に載せ，ハードウェア抽象化レイヤ（`c2a-hal`）を Rust で実装可能にし，Cargo で一撃でビルド・単体動作（S2E 不要の SILS）可能にするものを `examples/mobc` に導入します．

また，`examples/mobc` の CCSDS のエミュレーションのため，`c2a-example-mobc-ccsds-kble` crate を実装しています．これにより，テレコマ接続を [kble](https://github.com/arkedge/kble) 経由で引き回すことが可能です．

- runtime: `c2a-sils-runtime`
- HAL impl
  - `c2a-example-mobc-ccsds-kble`
  - `c2a-uart-kble`
  - `c2a-wdt-noop`

## 検証結果
`cargo run -p c2a-example-mobc`
![2023-08-02_17-05](https://github.com/arkedge/c2a-core/assets/23310673/5a3f3843-3856-47fa-8026-6c6db6b8df1f)

## 影響範囲
OSS 版 c2a-core mobc example が `cargo run` できるようになる