### PR TITLE
Fix missing Library rename in cargo config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 
 [workspace.dependencies]
 c2a-core = { path = "." }
-c2a-bind-utils = { path = "./Library/bind-utils" }
+c2a-bind-utils = { path = "./library/bind-utils" }
 
 c2a-sils-runtime = { path = "./sils-runtime" }
 c2a-wdt-noop = { path = "./hal/wdt-noop" }


### PR DESCRIPTION
## 概要
`Cargo.toml` 内の `Library` -> `library` の変更漏れを修正

## Issue / PR
- #10 
- #50 のやり残し