### PR TITLE
Pre Release (v4.0.0-beta.0): v4 の最初の beta release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "3.10.0"
+version = "4.0.0-beta.0"
 
 [workspace]
 resolver = "2"
@@ -54,7 +54,7 @@ no-c2a-link = []
 [build-dependencies]
 semver = "1.0.18"
 clang = "2.0.0"
-c2a-bind-utils = { path = "./library/bind-utils", version = "3.10" }    # TODO: release
+c2a-bind-utils = { path = "./library/bind-utils", version = "4.0.0-beta.0" }
 
 [dev-dependencies]
 # unit test 時に libC2A.a を要求しないようにする

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ no-c2a-link = []
 [build-dependencies]
 semver = "1.0.18"
 clang = "2.0.0"
-c2a-bind-utils = { path = "./library/bind-utils", version = "4.0.0-beta.0" }
+c2a-bind-utils = "4.0.0-beta.0"
 
 [dev-dependencies]
 # unit test 時に libC2A.a を要求しないようにする

--- a/c2a_core_main.h
+++ b/c2a_core_main.h
@@ -7,9 +7,9 @@ void C2A_core_main(void);
 // C2A の バージョンは Semantic Versioning を採用する
 // これらの番号は，リリース時に手動で合わせる
 // 詳細: docs/general/release.md
-#define C2A_CORE_VER_MAJOR (3)
-#define C2A_CORE_VER_MINOR (10)
+#define C2A_CORE_VER_MAJOR (4)
+#define C2A_CORE_VER_MINOR (0)
 #define C2A_CORE_VER_PATCH (0)
-#define C2A_CORE_VER_PRE   ("")
+#define C2A_CORE_VER_PRE   ("beta.0")
 
 #endif

--- a/library/bind-utils/Cargo.toml
+++ b/library/bind-utils/Cargo.toml
@@ -4,6 +4,8 @@ description = "C2Aのモジュールをbindgenするときのユーティリテ�
 version.workspace = true
 edition = "2021"
 
+license = "MIT"
+
 [dependencies]
 bindgen = "0.66.1"
 doxygen-rs = "0.4.2"


### PR DESCRIPTION
## 概要
Pre Release (v4.0.0-beta.0): v4 の最初の beta release

## Issue
- #2 

## 詳細
- 現状の c2a-core crate を publish したくなったことによる beta release
- `c2a-bind-utils` crate を publish し，crates.io からの参照に切り替えた

## 検証結果
既存の CI (pytest もふくむ！) がすべて通ること