### PR TITLE
Remove Renovate regexManager match v prefix

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
     {
       "fileMatch": [".github/workflows/*"],
       "matchStrings": [
-        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_VERSION:\\s(v|)(?<currentValue>.*)\\s",
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_VERSION:\\s(?<currentValue>.*)\\s",
       ],
       "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
     }


### PR DESCRIPTION
## 概要
#67 で `v` prefix の扱いを誤っていたので修正

## Issue / PR
- https://github.com/arkedge/c2a-core/issues/68#issuecomment-1681510542_            

## 詳細
regexManager の正規表現では `v` prefix にマッチさせなくする．そもそも今回の用途では `v` prefix を含むバージョン指定子は git tag の類であり，コード中に完全なモノが記述されるべき．

## 影響範囲
Renovate の workflow 向けの regexManager での更新