### PR TITLE
Use locked version dependencies for install jrsonnet

### DIFF
--- a/examples/mobc/tools/install.sh
+++ b/examples/mobc/tools/install.sh
@@ -8,4 +8,4 @@ cargo install --debug --root . tlmcmddb-cli    --version 0.2.0
 cargo install --debug --root . kble            --version 0.2.0
 cargo install --debug --root . kble-c2a        --version 0.2.0
 cargo install --debug --root . kble-eb90       --version 0.2.0
-cargo install --debug --root . jrsonnet        --version 0.5.0-pre9
+cargo install --debug --root . jrsonnet        --version 0.5.0-pre9 --locked

--- a/examples/subobc/tools/install.sh
+++ b/examples/subobc/tools/install.sh
@@ -8,4 +8,4 @@ cargo install --debug --root . tlmcmddb-cli    --version 0.2.0
 cargo install --debug --root . kble            --version 0.2.0
 cargo install --debug --root . kble-c2a        --version 0.2.0
 cargo install --debug --root . kble-eb90       --version 0.2.0
-cargo install --debug --root . jrsonnet        --version 0.5.0-pre9
+cargo install --debug --root . jrsonnet        --version 0.5.0-pre9 --locked


### PR DESCRIPTION
## 概要
`jrsonnet 0.5.0-pre9` は lock しないとビルドできないようになってしまっているので，lock してインストールするようにする

## Issue
- Resolve #76 

## 検証結果
キャッシュなしで pytest CI が通ればよし

## 影響範囲
C2A Boom のセットアップ（`npm install`）

## 補足
C2A Boom を導入済みの C2A user でも同様の対応をする必要がある