### PR TITLE
Pre Release (v4.0.0-beta.3): Refactor cmake option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@
 - [ut-issl/c2a-tlm-cmd-code-generator](https://github.com/ut-issl/c2a-tlm-cmd-code-generator) を c2a-core リポジトリで管理するように変更: [#111](https://github.com/arkedge/c2a-core/pull/111)
   - import したバージョン: [ut-issl/c2a-tlm-cmd-code-generator ae-v2.0.0](https://github.com/ut-issl/c2a-tlm-cmd-code-generator/releases/tag/ae-v2.0.0)
 - CMake option の整理: [#86](https://github.com/arkedge/c2a-core/pull/86)
-  - `C2A_` prefix に統一した他，意味が分かりにくい命名の変更，今後 optional としていく挙動を default OFF とした
+  - `C2A_` prefix に統一した（これはコーディング規約にも追加）
+  - 意味が分かりにくい命名の変更，今後 optional としていく挙動を default OFF とした
   - `option()` の挙動はユーザ指定によってかなり変わるため，該当する変更は単なるビルドチェックなどではなくすべて grep して変更すること
   - `BUILD_C2A_AS_UTF8` -> `C2A_BUILD_AS_UTF8`
   - `BUILD_C2A_AS_C99` -> `C2A_BUILD_AS_C99`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@
   - import したバージョン: [ut-issl/c2a-enum-loader ae-v2.0.0](https://github.com/ut-issl/c2a-enum-loader/releases/tag/ae-v2.0.0)
 - [ut-issl/c2a-tlm-cmd-code-generator](https://github.com/ut-issl/c2a-tlm-cmd-code-generator) を c2a-core リポジトリで管理するように変更: [#111](https://github.com/arkedge/c2a-core/pull/111)
   - import したバージョン: [ut-issl/c2a-tlm-cmd-code-generator ae-v2.0.0](https://github.com/ut-issl/c2a-tlm-cmd-code-generator/releases/tag/ae-v2.0.0)
+- CMake option の整理: [#86](https://github.com/arkedge/c2a-core/pull/86)
+  - `C2A_` prefix に統一した他，意味が分かりにくい命名の変更，今後 optional としていく挙動を default OFF とした
+  - `option()` の挙動はユーザ指定によってかなり変わるため，該当する変更は単なるビルドチェックなどではなくすべて grep して変更すること
+  - `BUILD_C2A_AS_UTF8` -> `C2A_BUILD_AS_UTF8`
+  - `BUILD_C2A_AS_C99` -> `C2A_BUILD_AS_C99`
+  - `BUILD_C2A_AS_CXX` -> `C2A_BUILD_AS_CXX`
+  - `(NOT USE_32BIT_COMPILER)` -> `C2A_BUILD_FOR_32BIT`: `ON` の時に明示的に 32bit ターゲットとしてビルドする（`-m32` をつける）
+  - `(NOT C2A_USE_STDINT_WRAPPER)` -> `C2A_USE_STDINT_WRAPPER`: C89 ターゲットでビルドする際に `ON` にすることでユーザ定義の `stdint.h` を使う
+  - `BUILD_C2A_AS_SILS_FW` -> `C2A_BUILD_FOR_SILS`
+  - `USE_ALL_C2A_CORE_APPS` -> `C2A_USE_ALL_CORE_APPS`
+  - `USE_ALL_C2A_CORE_TEST_APPS` -> `C2A_USE_ALL_CORE_TEST_APPS`
+  - `USE_ALL_C2A_CORE_LIB` -> `C2A_USE_ALL_CORE_LIB`
 
 
 ### Enhancements

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,10 @@ option(C2A_USE_STDINT_WRAPPER       "Use stdint.h wrapper for C89" OFF)
 
 option(C2A_BUILD_FOR_SILS           "Build C2A for SILS target" ON)
 
+## C2A core library select
+option(C2A_USE_ALL_CORE_APPS        "Use C2A-core all Applications" ON)
+
 # user config
-option(USE_ALL_C2A_CORE_APPS        "use C2A-core all Applications" ON)
 option(USE_ALL_C2A_CORE_TEST_APPS   "use C2A-core all Test Applications" ON)
 option(USE_ALL_C2A_CORE_LIB         "use C2A-core all library" ON)
 
@@ -84,7 +86,7 @@ endif()
 
 add_library(${PROJECT_NAME} OBJECT ${C2A_SRCS})
 
-if(USE_ALL_C2A_CORE_APPS)
+if(C2A_USE_ALL_CORE_APPS)
   add_subdirectory(applications)
   target_sources(${PROJECT_NAME} PUBLIC $<TARGET_OBJECTS:C2A_CORE_APPS>)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.13)
 
 project(C2A_CORE)
 
+# Build option
+## C2A compile config
+option(C2A_BUILD_AS_UTF8            "Build C2A as UTF-8" ON)
+
 # user config
 option(USE_ALL_C2A_CORE_APPS        "use C2A-core all Applications" ON)
 option(USE_ALL_C2A_CORE_TEST_APPS   "use C2A-core all Test Applications" ON)
@@ -14,7 +18,6 @@ option(C2A_USE_C99_STDINT           "use C99 standard stdint.h" ON)
 option(BUILD_C2A_AS_SILS_FW         "build C2A as SILS firmware" ON)
 option(BUILD_C2A_AS_C99             "build C2A as C99" OFF)
 option(BUILD_C2A_AS_CXX             "build C2A as C++" OFF)
-option(BUILD_C2A_AS_UTF8            "build C2A as UTF-8" ON)
 
 set(C2A_CORE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,13 +10,15 @@ option(C2A_BUILD_AS_CXX             "Build C2A as C++" OFF)
 
 option(C2A_BUILD_FOR_32BIT          "Build C2A for 32bit target(this will add -m32 option)" ON)
 
+## C2A
+option(C2A_USE_STDINT_WRAPPER       "Use stdint.h wrapper for C89" OFF)
+
 # user config
 option(USE_ALL_C2A_CORE_APPS        "use C2A-core all Applications" ON)
 option(USE_ALL_C2A_CORE_TEST_APPS   "use C2A-core all Test Applications" ON)
 option(USE_ALL_C2A_CORE_LIB         "use C2A-core all library" ON)
 
 option(C2A_USE_SIMPLE_LIBC          "use C2A-core hosted simple libc implementation" OFF)
-option(C2A_USE_C99_STDINT           "use C99 standard stdint.h" ON)
 
 option(BUILD_C2A_AS_SILS_FW         "build C2A as SILS firmware" ON)
 
@@ -56,8 +58,8 @@ set(C2A_SRCS
   tlm_cmd/ccsds/tlm_space_packet.c
 )
 
-if(NOT C2A_USE_C99_STDINT)
-  message("Use stdint.h wrapper")
+if(C2A_USE_STDINT_WRAPPER)
+  message("Use stdint.h wrapper for C89")
   include_directories(library/stdint_wrapper)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,9 @@ option(C2A_BUILD_FOR_SILS           "Build C2A for SILS target" ON)
 
 ## C2A core library select
 option(C2A_USE_ALL_CORE_APPS        "Use C2A-core all Applications" ON)
+option(C2A_USE_ALL_CORE_TEST_APPS   "Use C2A-core all Test Applications" ON)
 
 # user config
-option(USE_ALL_C2A_CORE_TEST_APPS   "use C2A-core all Test Applications" ON)
 option(USE_ALL_C2A_CORE_LIB         "use C2A-core all library" ON)
 
 option(C2A_USE_SIMPLE_LIBC          "use C2A-core hosted simple libc implementation" OFF)
@@ -91,7 +91,7 @@ if(C2A_USE_ALL_CORE_APPS)
   target_sources(${PROJECT_NAME} PUBLIC $<TARGET_OBJECTS:C2A_CORE_APPS>)
 endif()
 
-if(USE_ALL_C2A_CORE_TEST_APPS)
+if(C2A_USE_ALL_CORE_TEST_APPS)
   add_subdirectory(applications/test_app)
   target_sources(${PROJECT_NAME} PUBLIC $<TARGET_OBJECTS:C2A_CORE_TEST_APPS>)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(C2A_CORE)
 # Build option
 ## C2A compile config
 option(C2A_BUILD_AS_UTF8            "Build C2A as UTF-8" ON)
+option(C2A_BUILD_AS_C99             "Build C2A as C99" OFF)
 
 # user config
 option(USE_ALL_C2A_CORE_APPS        "use C2A-core all Applications" ON)
@@ -16,7 +17,6 @@ option(C2A_USE_SIMPLE_LIBC          "use C2A-core hosted simple libc implementat
 option(C2A_USE_C99_STDINT           "use C99 standard stdint.h" ON)
 
 option(BUILD_C2A_AS_SILS_FW         "build C2A as SILS firmware" ON)
-option(BUILD_C2A_AS_C99             "build C2A as C99" OFF)
 option(BUILD_C2A_AS_CXX             "build C2A as C++" OFF)
 
 set(C2A_CORE_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,12 @@ option(C2A_BUILD_AS_UTF8            "Build C2A as UTF-8" ON)
 option(C2A_BUILD_AS_C99             "Build C2A as C99" OFF)
 option(C2A_BUILD_AS_CXX             "Build C2A as C++" OFF)
 
+option(C2A_BUILD_FOR_32BIT          "Build C2A for 32bit target(this will add -m32 option)" ON)
+
 # user config
 option(USE_ALL_C2A_CORE_APPS        "use C2A-core all Applications" ON)
 option(USE_ALL_C2A_CORE_TEST_APPS   "use C2A-core all Test Applications" ON)
 option(USE_ALL_C2A_CORE_LIB         "use C2A-core all library" ON)
-option(USE_32BIT_COMPILER           "use 32bit compiler" OFF)
 
 option(C2A_USE_SIMPLE_LIBC          "use C2A-core hosted simple libc implementation" OFF)
 option(C2A_USE_C99_STDINT           "use C99 standard stdint.h" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,9 @@ option(C2A_BUILD_FOR_SILS           "Build C2A for SILS target" ON)
 ## C2A core library select
 option(C2A_USE_ALL_CORE_APPS        "Use C2A-core all Applications" ON)
 option(C2A_USE_ALL_CORE_TEST_APPS   "Use C2A-core all Test Applications" ON)
+option(C2A_USE_ALL_CORE_LIB         "Use C2A-core all library" ON)
 
-# user config
-option(USE_ALL_C2A_CORE_LIB         "use C2A-core all library" ON)
-
-option(C2A_USE_SIMPLE_LIBC          "use C2A-core hosted simple libc implementation" OFF)
+option(C2A_USE_SIMPLE_LIBC          "Use C2A-core hosted simple libc implementation" OFF)
 
 set(C2A_CORE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -96,7 +94,7 @@ if(C2A_USE_ALL_CORE_TEST_APPS)
   target_sources(${PROJECT_NAME} PUBLIC $<TARGET_OBJECTS:C2A_CORE_TEST_APPS>)
 endif()
 
-if(USE_ALL_C2A_CORE_LIB)
+if(C2A_USE_ALL_CORE_LIB)
   add_subdirectory(library)
   target_sources(${PROJECT_NAME} PUBLIC $<TARGET_OBJECTS:C2A_CORE_LIB>)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,14 +13,14 @@ option(C2A_BUILD_FOR_32BIT          "Build C2A for 32bit target(this will add -m
 ## C2A
 option(C2A_USE_STDINT_WRAPPER       "Use stdint.h wrapper for C89" OFF)
 
+option(C2A_BUILD_FOR_SILS           "Build C2A for SILS target" ON)
+
 # user config
 option(USE_ALL_C2A_CORE_APPS        "use C2A-core all Applications" ON)
 option(USE_ALL_C2A_CORE_TEST_APPS   "use C2A-core all Test Applications" ON)
 option(USE_ALL_C2A_CORE_LIB         "use C2A-core all library" ON)
 
 option(C2A_USE_SIMPLE_LIBC          "use C2A-core hosted simple libc implementation" OFF)
-
-option(BUILD_C2A_AS_SILS_FW         "build C2A as SILS firmware" ON)
 
 set(C2A_CORE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(C2A_CORE)
 ## C2A compile config
 option(C2A_BUILD_AS_UTF8            "Build C2A as UTF-8" ON)
 option(C2A_BUILD_AS_C99             "Build C2A as C99" OFF)
+option(C2A_BUILD_AS_CXX             "Build C2A as C++" OFF)
 
 # user config
 option(USE_ALL_C2A_CORE_APPS        "use C2A-core all Applications" ON)
@@ -17,7 +18,6 @@ option(C2A_USE_SIMPLE_LIBC          "use C2A-core hosted simple libc implementat
 option(C2A_USE_C99_STDINT           "use C99 standard stdint.h" ON)
 
 option(BUILD_C2A_AS_SILS_FW         "build C2A as SILS firmware" ON)
-option(BUILD_C2A_AS_CXX             "build C2A as C++" OFF)
 
 set(C2A_CORE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -75,7 +75,7 @@ execute_process(
 add_definitions("-DGIT_REVISION_C2A_CORE=\"${GIT_REVISION_C2A_CORE}\"")
 add_definitions("-DGIT_REVISION_C2A_CORE_SHORT=0x${GIT_REVISION_C2A_CORE_SHORT}")
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ option(C2A_USE_ALL_CORE_APPS        "Use C2A-core all Applications" ON)
 option(C2A_USE_ALL_CORE_TEST_APPS   "Use C2A-core all Test Applications" ON)
 option(C2A_USE_ALL_CORE_LIB         "Use C2A-core all library" ON)
 
-option(C2A_USE_SIMPLE_LIBC          "Use C2A-core hosted simple libc implementation" OFF)
+option(C2A_USE_SIMPLE_LIBC          "Use C2A-core hosted simple libc (c2a-core/library/libc) implementation" OFF)
 
 set(C2A_CORE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -15,7 +15,7 @@ set(C2A_SRCS
   telemetry_manager.c
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 

--- a/applications/test_app/CMakeLists.txt
+++ b/applications/test_app/CMakeLists.txt
@@ -6,7 +6,7 @@ set(C2A_SRCS
   test_ccp_util.c
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 

--- a/common.cmake
+++ b/common.cmake
@@ -20,7 +20,7 @@ else()
   endif()
 endif()
 
-if(BUILD_C2A_AS_SILS_FW)
+if(C2A_BUILD_FOR_SILS )
   target_compile_definitions(${PROJECT_NAME} PUBLIC SILS_FW)
 endif()
 

--- a/common.cmake
+++ b/common.cmake
@@ -31,7 +31,7 @@ if(MSVC)
   if(BUILD_C2A_AS_CXX)
     target_compile_options(${PROJECT_NAME} PUBLIC "/TP") # Compile C codes as C++
   endif()
-  if(BUILD_C2A_AS_UTF8)
+  if(C2A_BUILD_AS_UTF8)
     target_compile_options(${PROJECT_NAME} PUBLIC "/source-charset:utf-8")
   endif()
 

--- a/common.cmake
+++ b/common.cmake
@@ -45,7 +45,7 @@ else()
   # endif()
 
   # 32bit
-  if(NOT USE_32BIT_COMPILER)
+  if(C2A_BUILD_FOR_32BIT)
     target_compile_options(${PROJECT_NAME} PUBLIC "-m32")
     target_link_options(${PROJECT_NAME} PRIVATE "-m32")
   endif()

--- a/common.cmake
+++ b/common.cmake
@@ -2,7 +2,7 @@ if(BUILD_C2A_AS_CXX)
   # memo: set_source_files_properties() must be set before add_library/add_executable on Visual Studio CMake
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 else()
-  if(BUILD_C2A_AS_C99)
+  if(C2A_BUILD_AS_C99)
     set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 99) # C99
   else()
     if (CMAKE_C_COMPILER_ID STREQUAL "Clang")

--- a/common.cmake
+++ b/common.cmake
@@ -1,4 +1,4 @@
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   # memo: set_source_files_properties() must be set before add_library/add_executable on Visual Studio CMake
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 else()
@@ -28,7 +28,7 @@ endif()
 if(MSVC)
   target_compile_options(${PROJECT_NAME} PUBLIC "/W4")
   target_compile_options(${PROJECT_NAME} PUBLIC "/MT")
-  if(BUILD_C2A_AS_CXX)
+  if(C2A_BUILD_AS_CXX)
     target_compile_options(${PROJECT_NAME} PUBLIC "/TP") # Compile C codes as C++
   endif()
   if(C2A_BUILD_AS_UTF8)

--- a/docs/general/coding_rule.md
+++ b/docs/general/coding_rule.md
@@ -213,6 +213,11 @@ typedef uint32_t flash_block_t;
 
 
 ## 個別箇所についての命名など [M]
+### CMake option
+- 接頭辞は `C2A_` で統一する
+  - 特定の C2A user 固有のものや，C2A 以外の文脈が含まれる場合は必須ではない
+
+
 ### applications/user_defined
 - ファイル名と AppInfo 構造体名を一致させる（スタイルを除く）
 - AppInfo 構造体名とそのインスタンス名を一致させる（スタイルを除く）

--- a/docs/general/coding_rule.md
+++ b/docs/general/coding_rule.md
@@ -214,6 +214,7 @@ typedef uint32_t flash_block_t;
 
 ## 個別箇所についての命名など [M]
 ### CMake option
+- 大文字の snake case
 - 接頭辞は `C2A_` で統一する
   - 特定の C2A user 固有のものや，C2A 以外の文脈が含まれる場合は必須ではない
 

--- a/docs/sils/s2e_integration.md
+++ b/docs/sils/s2e_integration.md
@@ -4,11 +4,11 @@ C2A 標準 SILS として， S2E (FIXME: 公開後にリンクを貼る) とい�
 これにより，フライトソフトウェアである C2A を S2E 内部で動かすことが可能である．  
 詳細はS2Eドキュメント (TBA) を参照のこと．
 
-現行の S2E では C2A を C++ としてビルドしなければならないため，その際は `BUILD_C2A_AS_CXX` というオプションを使用してビルドする．
+現行の S2E では C2A を C++ としてビルドしなければならないため，その際は `C2A_BUILD_AS_CXX` というオプションを使用してビルドする．
 （[オプションの追加経緯](https://github.com/ut-issl/c2a-core/pull/35)）
 
 具体的には， S2E 側の `CMakeLists.txt` を次のようにする．
 ```
-  set(BUILD_C2A_AS_CXX ON)
-  add_subdirectory(${C2A_DIR} C2A_CORE)
+  set(C2A_BUILD_AS_CXX ON)
+  add_subdirectory(${C2A_DIR} C2A)
 ```

--- a/examples/mobc/CMakeLists.txt
+++ b/examples/mobc/CMakeLists.txt
@@ -21,11 +21,11 @@ option(USE_SILS_MOCKUP "Use SILS mockup for build C2A with minimal user in C89 o
 option(BUILD_C2A_AS_SILS_FW "Build C2A as SILS firmware" ON)
 
 if(USE_SILS_MOCKUP)
-  set(BUILD_C2A_AS_CXX OFF)
+  set(C2A_BUILD_AS_CXX OFF)
 endif()
 
-if(BUILD_C2A_AS_CXX)
-  message("build C2A as C++!")
+if(C2A_BUILD_AS_CXX)
+  message("Build C2A as C++!")
 endif()
 
 set(C2A_CORE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/src_core)
@@ -69,7 +69,7 @@ set(C2A_SRCS
   ${C2A_USER_DIR}/c2a_main.c
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   message("Build as C++!!!")
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()

--- a/examples/mobc/CMakeLists.txt
+++ b/examples/mobc/CMakeLists.txt
@@ -18,7 +18,7 @@ option(USE_SCI_COM_UART "Use SCI_COM_UART" OFF)
 
 option(USE_SILS_MOCKUP "Use SILS mockup for build C2A with minimal user in C89 only" OFF)
 
-option(BUILD_C2A_AS_SILS_FW "Build C2A as SILS firmware" ON)
+option(C2A_BUILD_FOR_SILS "Build C2A for SILS target" ON)
 
 if(USE_SILS_MOCKUP)
   set(C2A_BUILD_AS_CXX OFF)

--- a/examples/mobc/build.rs
+++ b/examples/mobc/build.rs
@@ -5,7 +5,7 @@ fn main() {
         .very_verbose(true)
         .define("C2A_BUILD_FOR_32BIT", "OFF")
         .define("C2A_BUILD_AS_C99", "ON")
-        .define("BUILD_C2A_AS_SILS_FW", "ON")
+        .define("C2A_BUILD_FOR_SILS", "ON")
         .define("USE_SCI_COM_WINGS", "OFF")
         .build_target("C2A");
 

--- a/examples/mobc/build.rs
+++ b/examples/mobc/build.rs
@@ -4,7 +4,7 @@ fn main() {
     let libc2a = c2a_cmake
         .very_verbose(true)
         .define("USE_32BIT_COMPILER", "ON")
-        .define("BUILD_C2A_AS_C99", "ON")
+        .define("C2A_BUILD_AS_C99", "ON")
         .define("BUILD_C2A_AS_SILS_FW", "ON")
         .define("USE_SCI_COM_WINGS", "OFF")
         .build_target("C2A");

--- a/examples/mobc/build.rs
+++ b/examples/mobc/build.rs
@@ -3,7 +3,7 @@ fn main() {
     let mut c2a_cmake = cmake::Config::new(".");
     let libc2a = c2a_cmake
         .very_verbose(true)
-        .define("USE_32BIT_COMPILER", "ON")
+        .define("C2A_BUILD_FOR_32BIT", "OFF")
         .define("C2A_BUILD_AS_C99", "ON")
         .define("BUILD_C2A_AS_SILS_FW", "ON")
         .define("USE_SCI_COM_WINGS", "OFF")

--- a/examples/mobc/src/s2e_mockup/CMakeLists.txt
+++ b/examples/mobc/src/s2e_mockup/CMakeLists.txt
@@ -15,7 +15,7 @@ set(C2A_DIR ../..)
 # include_directories
 include_directories(${C2A_DIR}/src)
 # add subdirectory
-set(BUILD_C2A_AS_CXX ON)    # Build C2A as C++
+set(C2A_BUILD_AS_CXX ON)    # Build C2A as C++
 add_subdirectory(${C2A_DIR} C2A)
 
 add_executable(${PROJECT_NAME} main.cpp)

--- a/examples/mobc/src/src_user/Drivers/CMakeLists.txt
+++ b/examples/mobc/src/src_user/Drivers/CMakeLists.txt
@@ -10,7 +10,7 @@ set(C2A_SRCS
   Etc/uart_test.c
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 

--- a/examples/mobc/src/src_user/Settings/CMakeLists.txt
+++ b/examples/mobc/src/src_user/Settings/CMakeLists.txt
@@ -19,7 +19,7 @@ set(C2A_SRCS
   tlm_cmd/ccsds/apid_define.c
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 

--- a/examples/mobc/src/src_user/applications/CMakeLists.txt
+++ b/examples/mobc/src/src_user/applications/CMakeLists.txt
@@ -10,7 +10,7 @@ set(C2A_SRCS
   user_defined/debug_apps.c
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 

--- a/examples/mobc/src/src_user/hal/CMakeLists.txt
+++ b/examples/mobc/src/src_user/hal/CMakeLists.txt
@@ -56,7 +56,7 @@ set(C2A_SRCS
   ${C2A_HAL_IMPL_SRCS}
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 

--- a/examples/mobc/src/src_user/library/CMakeLists.txt
+++ b/examples/mobc/src/src_user/library/CMakeLists.txt
@@ -7,7 +7,7 @@ set(C2A_SRCS
   vt100.c
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 

--- a/examples/mobc/src/src_user/tlm_cmd/CMakeLists.txt
+++ b/examples/mobc/src/src_user/tlm_cmd/CMakeLists.txt
@@ -21,7 +21,7 @@ set(C2A_SRCS
   ccsds/vcdu.c
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 

--- a/examples/subobc/CMakeLists.txt
+++ b/examples/subobc/CMakeLists.txt
@@ -14,8 +14,8 @@ option(USE_SILS_MOCKUP "Use SILS mockup for build C2A with minimal user in C89 o
 
 option(C2A_BUILD_FOR_SILS "Build C2A for SILS target" ON)
 
-set(USE_ALL_C2A_CORE_APPS OFF)
 # Core App のターゲット追加は src_user/applications/CMakeLists.txt で行う
+set(C2A_USE_ALL_CORE_APPS OFF)
 set(USE_ALL_C2A_CORE_TEST_APPS OFF)
 
 if(USE_SILS_MOCKUP)

--- a/examples/subobc/CMakeLists.txt
+++ b/examples/subobc/CMakeLists.txt
@@ -19,10 +19,10 @@ set(USE_ALL_C2A_CORE_APPS OFF)
 set(USE_ALL_C2A_CORE_TEST_APPS OFF)
 
 if(USE_SILS_MOCKUP)
-  set(BUILD_C2A_AS_CXX OFF)
+  set(C2A_BUILD_AS_CXX OFF)
 endif()
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   message("build C2A as C++!")
 endif()
 
@@ -67,7 +67,7 @@ set(C2A_SRCS
   ${C2A_USER_DIR}/c2a_main.c
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   message("Build as C++!!!")
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()

--- a/examples/subobc/CMakeLists.txt
+++ b/examples/subobc/CMakeLists.txt
@@ -12,7 +12,7 @@ option(USE_SCI_COM_WINGS "Use SCI_COM_WINGS" ON)
 
 option(USE_SILS_MOCKUP "Use SILS mockup for build C2A with minimal user in C89 only" OFF)
 
-option(BUILD_C2A_AS_SILS_FW "Build C2A as SILS firmware" ON)
+option(C2A_BUILD_FOR_SILS "Build C2A for SILS target" ON)
 
 set(USE_ALL_C2A_CORE_APPS OFF)
 # Core App のターゲット追加は src_user/applications/CMakeLists.txt で行う

--- a/examples/subobc/CMakeLists.txt
+++ b/examples/subobc/CMakeLists.txt
@@ -16,7 +16,7 @@ option(C2A_BUILD_FOR_SILS "Build C2A for SILS target" ON)
 
 # Core App のターゲット追加は src_user/applications/CMakeLists.txt で行う
 set(C2A_USE_ALL_CORE_APPS OFF)
-set(USE_ALL_C2A_CORE_TEST_APPS OFF)
+set(C2A_USE_ALL_CORE_TEST_APPS OFF)
 
 if(USE_SILS_MOCKUP)
   set(C2A_BUILD_AS_CXX OFF)

--- a/examples/subobc/build.rs
+++ b/examples/subobc/build.rs
@@ -3,7 +3,7 @@ fn main() {
     let mut c2a_cmake = cmake::Config::new(".");
     let libc2a = c2a_cmake
         .very_verbose(true)
-        .define("USE_32BIT_COMPILER", "ON")
+        .define("C2A_BUILD_FOR_32BIT", "ON")
         .define("C2A_BUILD_AS_C99", "ON")
         .define("BUILD_C2A_AS_SILS_FW", "ON")
         .define("USE_SCI_COM_WINGS", "OFF")

--- a/examples/subobc/build.rs
+++ b/examples/subobc/build.rs
@@ -5,7 +5,7 @@ fn main() {
         .very_verbose(true)
         .define("C2A_BUILD_FOR_32BIT", "ON")
         .define("C2A_BUILD_AS_C99", "ON")
-        .define("BUILD_C2A_AS_SILS_FW", "ON")
+        .define("C2A_BUILD_FOR_SILS ", "ON")
         .define("USE_SCI_COM_WINGS", "OFF")
         .build_target("C2A");
 

--- a/examples/subobc/build.rs
+++ b/examples/subobc/build.rs
@@ -4,7 +4,7 @@ fn main() {
     let libc2a = c2a_cmake
         .very_verbose(true)
         .define("USE_32BIT_COMPILER", "ON")
-        .define("BUILD_C2A_AS_C99", "ON")
+        .define("C2A_BUILD_AS_C99", "ON")
         .define("BUILD_C2A_AS_SILS_FW", "ON")
         .define("USE_SCI_COM_WINGS", "OFF")
         .build_target("C2A");

--- a/examples/subobc/src/s2e_mockup/CMakeLists.txt
+++ b/examples/subobc/src/s2e_mockup/CMakeLists.txt
@@ -15,7 +15,7 @@ set(C2A_DIR ../..)
 # include_directories
 include_directories(${C2A_DIR}/src)
 # add subdirectory
-set(BUILD_C2A_AS_CXX ON)    # Build C2A as C++
+set(C2A_BUILD_AS_CXX ON)    # Build C2A as C++
 add_subdirectory(${C2A_DIR} C2A)
 
 add_executable(${PROJECT_NAME} main.cpp)

--- a/examples/subobc/src/src_user/Drivers/CMakeLists.txt
+++ b/examples/subobc/src/src_user/Drivers/CMakeLists.txt
@@ -6,7 +6,7 @@ set(C2A_SRCS
   Etc/mobc.c
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 

--- a/examples/subobc/src/src_user/Settings/CMakeLists.txt
+++ b/examples/subobc/src/src_user/Settings/CMakeLists.txt
@@ -16,7 +16,7 @@ set(C2A_SRCS
   tlm_cmd/ccsds/apid_define.c
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 

--- a/examples/subobc/src/src_user/applications/CMakeLists.txt
+++ b/examples/subobc/src/src_user/applications/CMakeLists.txt
@@ -13,7 +13,7 @@ set(C2A_SRCS
   ${C2A_CORE_DIR}/applications/timeline_command_dispatcher.c
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 

--- a/examples/subobc/src/src_user/hal/CMakeLists.txt
+++ b/examples/subobc/src/src_user/hal/CMakeLists.txt
@@ -44,7 +44,7 @@ set(C2A_SRCS
   ${C2A_HAL_IMPL_SRCS}
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 

--- a/examples/subobc/src/src_user/library/CMakeLists.txt
+++ b/examples/subobc/src/src_user/library/CMakeLists.txt
@@ -7,7 +7,7 @@ set(C2A_SRCS
   vt100.c
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 

--- a/examples/subobc/src/src_user/tlm_cmd/CMakeLists.txt
+++ b/examples/subobc/src/src_user/tlm_cmd/CMakeLists.txt
@@ -14,7 +14,7 @@ set(C2A_SRCS
   normal_block_command_definition/nbc_start_hk_tlm.c
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -21,7 +21,7 @@ set(C2A_SRCS
   ${C2A_LIBC_SRC}
 )
 
-if(BUILD_C2A_AS_CXX)
+if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 

--- a/library/stdint_wrapper/stdint.h
+++ b/library/stdint_wrapper/stdint.h
@@ -7,7 +7,7 @@
 #define STDINT_H_
 
 // C99 stdint.h ないしはそれと同等のヘッダへのラッパー用ヘッダ
-// 実機向けのコンパイラが C89 であるときのみ使用すること（CMake では C2A_USE_C99_STDINT=OFF すること）
+// 実機向けのコンパイラが C89 であるときのみ使用すること（CMake では C2A_USE_STDINT_WRAPPER=ON すること）
 
 #ifdef SILS_FW
 #include <stdint.h> // このヘッダを使う OBC であっても，SILS 環境下では C99 stdint.h が存在することが期待できる


### PR DESCRIPTION
## 概要
散らかっている CMake option を整理する

## Issue
- #2 

## 詳細
- `C2A_` prefix に揃える
- 元々の挙動だったが今後は optional としていくオプションは default OFF となるようにする

## 影響範囲
`BUILD-C2A_AS_SILS_FW` など，外部（SILS-S2E, c2a-runtime の `build.rs`）から使っていたオプションの名前が変わるため，breaking

## 備考
- [ ] マージ前にバージョンを上げる