### PR TITLE
Move check coding rule setting file to C2A user top

### DIFF
--- a/examples/mobc/check_coding_rule.json
+++ b/examples/mobc/check_coding_rule.json
@@ -1,17 +1,16 @@
 {
-  "c2a_root_dir" : "./",
   "input_file_encoding" : "utf-8",
   "target_dirs" : [
-    "src_core/",
-    "src_user/"
+    "src/src_core/",
+    "src/src_user/"
   ],
   "ignore_dirs" : [
-    "src_core/examples",
-    "src_core/docs",
-    "src_core/script"
+    "src/src_core/examples",
+    "src/src_core/docs",
+    "src/src_core/script"
   ],
   "ignore_files" : [
-    "src_user/tlm_cmd/telemetry_definitions.c"
+    "src/src_user/tlm_cmd/telemetry_definitions.c"
   ],
   "ignore_rules" : [
   ],

--- a/examples/subobc/check_coding_rule.json
+++ b/examples/subobc/check_coding_rule.json
@@ -1,0 +1,40 @@
+{
+  "input_file_encoding" : "utf-8",
+  "target_dirs" : [
+    "src/src_core/",
+    "src/src_user/"
+  ],
+  "ignore_dirs" : [
+    "src/src_core/examples",
+    "src/src_core/docs",
+    "src/src_core/script"
+  ],
+  "ignore_files" : [
+    "src/src_user/tlm_cmd/telemetry_definitions.c"
+  ],
+  "ignore_rules" : [
+  ],
+  "comment_ignore_rules" : [
+    "以下を指定すると，該当ルールが無視される",
+    "comment",
+    "newline",
+    "eof",
+    "space",
+    "operator_space",
+    "preprocessor",
+    "include_guard"
+  ],
+  "additional_type" : [
+    "TCP",
+    "CommonTlmCmdPacket",
+    "CommonTlmPacket",
+    "CommonCmdPacket",
+    "SpacePacket",
+    "TlmSpacePacket",
+    "CmdSpacePacket"
+  ],
+  "comment_additional_type" : [
+    "FIXME: TCP はもう存在しないはずなので，どこかで消す",
+    "FIXME: CTCP, CTP, CCP については，整理が終わり次第，消して大丈夫になるはず"
+  ]
+}

--- a/script/ci/check_coding_rule.py
+++ b/script/ci/check_coding_rule.py
@@ -59,7 +59,9 @@ def main():
             print("WARNING: " + rule_name + " rule is ignored!!")
     settings["check_funcs"] = check_funcs  # ここだけ， settings に追記している
 
-    if not check_coding_rule(settings):
+    check_root_dir = os.path.dirname(setting_file_path) + r"/"
+
+    if not check_coding_rule(check_root_dir, settings):
         print("The above files are invalid coding rule.")
         sys.exit(1)
     print("Completed!")
@@ -67,18 +69,18 @@ def main():
 
 
 # True: OK, False: NG
-def check_coding_rule(settings: dict) -> bool:
+def check_coding_rule(check_root_dir: str, settings: dict) -> bool:
     flag = True
 
     target_dirs = []
     for target_dir in settings["target_dirs"]:
-        target_dirs.append(settings["c2a_root_dir"] + target_dir)
+        target_dirs.append(check_root_dir + target_dir)
     ignore_dirs = []
     for ignore_dir in settings["ignore_dirs"]:
-        ignore_dirs.append(settings["c2a_root_dir"] + ignore_dir)
+        ignore_dirs.append(check_root_dir + ignore_dir)
     ignore_files = []
     for ignore_file in settings["ignore_files"]:
-        ignore_files.append(settings["c2a_root_dir"] + ignore_file)
+        ignore_files.append(check_root_dir + ignore_file)
 
     preprocess_(target_dirs, ignore_dirs, ignore_files, settings)
 


### PR DESCRIPTION
## 概要
コーディングルールのスクリプトによるチェックを設定ファイル（`check_coding_rule.json`）があるディレクトリの配下に対して実施するように変更し，C2A user では `check_coding_rule.json` をトップディレクトリに置くように標準化します．

これにより，`check_coding_rule.py` の挙動が CWD によって変化するという非常に confusing な事態の根本的な解決をします．

## Issue / PR
- #28 
- https://github.com/arkedge/workflows-c2a/pull/41

## 詳細
- `check_coding_rule.json` の `c2a_root_dir` を廃止した．理由は以下のようにあまりにも confusing なため
  - そもそも「C2A root dir」なる概念は undocumented である上に，C2A user のトップディレクトリではなく `src/` のこと（であることを概ね期待している）
  - 設定ファイルが置かれる `src/src_user/script/ci/` から `src/` への相対パスであるかのように予想されるがそんなことは一切なく，概ね `src/src_core/script/ci` に `cd` して実行されることを期待した上でその実行パスからの相対パスになっている
  - この仕様はあまりにも分かりにくいため，上記の期待は一部の C2A user では守られていなかった
    - この問題は workflows-c2a によって全 C2A user で統一的な方法で `check_coding_rule.py` を実行するようになったことでようやく発覚・顕在化した
  - c2a-core では見た目上は C2A user （の `src/src_user`）と同じ場所である `script/ci/` 配下に `check_coding_rule.json` が置かれていたが，ここではなぜか `c2a_root_dir` の意味が変わっていた（おそらく example user の `src` から実行することを期待している？）
- `<c2a-core>/script/ci/check_coding_rule.json` を削除
  - 上記のように，なぜか C2A user とセマンティクスが変わって confusing であるため
  - また，c2a-core の開発においては，example user に対するチェックでワークするため
    - これについてはやり方を考えてもよいが，一旦は simple にすることを優先するため，別途やりたい
- `check_coding_rule.py` のファイル探索範囲を `check_coding_rule.json` のあるディレクトリ以下に変更した
- `check_coding_rule.json` を （c2a-core example user 含め）C2A user のトップディレクトリに置くように標準化する
  - これに伴い，設定ファイル中のディレクトリの設定は C2A user のトップディレクトリからの相対パスになる
  - これはほとんどの場合 `src/src_user/***` になるはず

## 検証結果
workflows-c2a でのサポートは別途行うため，手元で `python script/ci/check_coding_rule.py examples/mobc/check_coding_rule.json` のように実行する

## 影響範囲
- 全 C2A user のコーディングルールのチェック及びその設定ファイル
- workflows-c2a

## 補足
何かあれば