### PR TITLE
Switch rye build-system backend from hatchling to pdm

### DIFF
--- a/examples/mobc/src/src_user/Test/pyproject.toml
+++ b/examples/mobc/src/src_user/Test/pyproject.toml
@@ -13,8 +13,8 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
 [tool.rye]
 managed = true

--- a/examples/subobc/src/src_user/Test/pyproject.toml
+++ b/examples/subobc/src/src_user/Test/pyproject.toml
@@ -13,8 +13,8 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
 [tool.rye]
 managed = true


### PR DESCRIPTION
## 概要
pytest で使っている rye の `build-backend` を [hatchling](https://pypi.org/project/hatchling/) から [pdm](https://pdm.fming.dev/) に切り替えます

## Issue / PR
- https://github.com/mitsuhiko/rye/issues/379
- #99 

## 詳細
rye のデフォルトで指定される `hatchling` では相対パスでの dependency ができなくて困るのと，特に理由があって `hatchling` を使っていたわけではない（単にデフォルトの `rye init` で出てくるだけ）なので，切り替えて問題ないはずです．

これにより，#99 のような c2a-core リポジトリに内包する Python ライブラリを rye から相対パスで参照できるようになります．ただし，これでも lockfile には絶対パスが焼かれてしまいます．が，これは一旦どうしようもないので許容することとします（これの後に別方向の解決を試みます）．

## 検証結果
example user の `src/src_user/Test` で `rye sync` できればよし

## 影響範囲
example user の pytest