### PR TITLE
Add example user's tlm_cmd code generation check workflow

### DIFF
--- a/.github/workflows/check_code_generation.yml
+++ b/.github/workflows/check_code_generation.yml
@@ -32,6 +32,5 @@ jobs:
           git add .
           if ! git diff --exit-code --cached; then
             echo "threre are some diff after code generation"
-            git diff HEAD
             exit 1
           fi

--- a/.github/workflows/check_code_generation.yml
+++ b/.github/workflows/check_code_generation.yml
@@ -1,0 +1,37 @@
+name: check tlm_cmd code generation
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+
+jobs:
+  check_code_generate:
+    strategy:
+      fail-fast: false
+      matrix:
+        user:
+          - mobc
+          - subobc
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: run tlm-cmd-code-generator
+        working-directory: ./tlm-cmd-code-generator
+        run: |
+          cp "./settings_${{ matrix.user }}.json" ./settings.json
+          python GenerateC2ACode.py
+
+      - name: check diff
+        run: |
+          git add .
+          if ! git diff --exit-code --cached; then
+            echo "threre are some diff after code generation"
+            git diff HEAD
+            exit 1
+          fi

--- a/tlm-cmd-code-generator/.gitignore
+++ b/tlm-cmd-code-generator/.gitignore
@@ -1,3 +1,5 @@
+settings.json
+
 # OSX
 .DS_Store
 .AppleDouble


### PR DESCRIPTION
## 概要
example user 向けのコード生成のチェックをする CI を追加する

## Issue / PR
- #111 
- #117 

## 詳細
#111 で c2a-tlm-cmd-code-generator が c2a-core リポジトリに取り込まれ，#117 で example user 用の設定が追加された．
そこで，CI 上で example user のコード生成ができるか，また，正しくコード生成が行われているか（commit されているコードが最新の状態でコード生成されたものか）を確認する CI を追加する．

## 検証結果
コード生成されるはずのファイルが誤った状態になっている時に CI が fail し，正しい時に CI が通ればよし

## 影響範囲
example user のコード生成が正しく行われているかどうかが status check で分かるようになる