### PR TITLE
Import README.md as crate documentation

### DIFF
--- a/c2a_core.rs
+++ b/c2a_core.rs
@@ -3,6 +3,8 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
+#![allow(rustdoc::bare_urls)]
+#![doc = include_str!("README.md")]
 
 use core::*;
 include!(concat!(env!("OUT_DIR"), "/c2a_core_main.rs"));


### PR DESCRIPTION
## 概要
README を crate のドキュメントとして取り込む

## 詳細
cargo の external-doc を使って `README.md` を rustdoc として使う

## 検証結果
`cargo doc --open` して `README.md` の内容がトップページに取り込まれていればよし

## 影響範囲
docs.rs の `c2a-core` crate のトップページで `README.md` の内容が表示される