### PR TITLE
Refactor user cmake option

### DIFF
--- a/examples/mobc/CMakeLists.txt
+++ b/examples/mobc/CMakeLists.txt
@@ -16,11 +16,11 @@ option(USE_SCI_COM_WINGS "Use SCI_COM_WINGS" ON)
 # そちらのバッファが詰まってSILSの動作が止まることがあるので注意すること！
 option(USE_SCI_COM_UART "Use SCI_COM_UART" OFF)
 
-option(USE_SILS_MOCKUP "Use SILS mockup for build C2A with minimal user in C89 only" OFF)
+option(C2A_BUILD_WITH_SILS_MOCKUP "Build C2A with SILS mockup for check undefined symbols by build minimal C2A user executable(C89 only)" OFF)
 
 option(C2A_BUILD_FOR_SILS "Build C2A for SILS target" ON)
 
-if(USE_SILS_MOCKUP)
+if(C2A_BUILD_WITH_SILS_MOCKUP)
   set(C2A_BUILD_AS_CXX OFF)
 endif()
 
@@ -74,7 +74,7 @@ if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 
-if(USE_SILS_MOCKUP)
+if(C2A_BUILD_WITH_SILS_MOCKUP)
   add_definitions(-DDEFINE_MAIN_ON_SILS)
   add_executable(${PROJECT_NAME} ${C2A_SRCS})
 else()

--- a/examples/mobc/CMakeLists.txt
+++ b/examples/mobc/CMakeLists.txt
@@ -34,9 +34,8 @@ set(C2A_USER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/src_user)
 include_directories(src)
 
 # Output debug print to SILS console window
-option(SHOW_DEBUG_PRINT_ON_SILS "Show debug print")
-set(SHOW_DEBUG_PRINT_ON_SILS ON)
-if(SHOW_DEBUG_PRINT_ON_SILS)
+option(C2A_SHOW_DEBUG_PRINT_ON_SILS "Show debug print" ON)
+if(C2A_SHOW_DEBUG_PRINT_ON_SILS)
   add_definitions(-DSHOW_DEBUG_PRINT_ON_SILS)
   message("Show debug print")
 endif()

--- a/examples/mobc/CMakeLists.txt
+++ b/examples/mobc/CMakeLists.txt
@@ -8,13 +8,13 @@ project(C2A)
 # ！！！注意！！！
 # これをONにした状態で，SCIの受け口がない場合（TMTC IFが動いてない状態）
 # そちらのバッファが詰まってSILSの動作が止まることがあるので注意すること！
-option(USE_SCI_COM_WINGS "Use SCI_COM_WINGS" ON)
+option(C2A_USE_SCI_COM_WINGS "Use SCI_COM_WINGS" ON)
 
 # SCI COM for connection to PC UART
 # ！！！注意！！！
 # これをONにした状態で，SCIの受け口がない場合（受けてのTeratermが起動していない状態）
 # そちらのバッファが詰まってSILSの動作が止まることがあるので注意すること！
-option(USE_SCI_COM_UART "Use SCI_COM_UART" OFF)
+option(C2A_USE_SCI_COM_UART "Use SCI_COM_UART" OFF)
 
 option(C2A_BUILD_WITH_SILS_MOCKUP "Build C2A with SILS mockup for check undefined symbols by build minimal C2A user executable(C89 only)" OFF)
 

--- a/examples/mobc/build.rs
+++ b/examples/mobc/build.rs
@@ -6,7 +6,7 @@ fn main() {
         .define("C2A_BUILD_FOR_32BIT", "OFF")
         .define("C2A_BUILD_AS_C99", "ON")
         .define("C2A_BUILD_FOR_SILS", "ON")
-        .define("USE_SCI_COM_WINGS", "OFF")
+        .define("C2A_USE_SCI_COM_WINGS", "OFF")
         .build_target("C2A");
 
     println!("cargo:rerun-if-changed=./src/src_core");

--- a/examples/mobc/src/src_user/hal/CMakeLists.txt
+++ b/examples/mobc/src/src_user/hal/CMakeLists.txt
@@ -7,7 +7,7 @@ set(C2A_COMMON_SRCS
 )
 
 # 通常，S2EではC++ビルドされるが，C2A core開発のため，C2A単体をC89でライブラリビルドする場合は，mockupをビルド対象にする
-if(USE_SILS_MOCKUP)
+if(C2A_BUILD_WITH_SILS_MOCKUP)
   message("USE SILS_MOCKUP")
 
   #target_sources(${PROJECT_NAME} PRIVATE

--- a/examples/mobc/src/src_user/hal/CMakeLists.txt
+++ b/examples/mobc/src/src_user/hal/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
     sils/wdt_sils.cpp
   )
 
-  if(USE_SCI_COM_WINGS)
+  if(C2A_USE_SCI_COM_WINGS)
     add_definitions(-DUSE_SCI_COM_WINGS)
     #target_sources(${PROJECT_NAME} PUBLIC
     set(C2A_HAL_COM_WINGS_SRCS
@@ -35,7 +35,7 @@ else()
     message("USE SCI_COM_WINGS")
   endif()
 
-  if(USE_SCI_COM_UART)
+  if(C2A_USE_SCI_COM_UART)
     add_definitions(-DUSE_SCI_COM_UART)
     #target_sources(${PROJECT_NAME} PUBLIC
     set(C2A_HAL_COM_UART_SRCS

--- a/examples/subobc/CMakeLists.txt
+++ b/examples/subobc/CMakeLists.txt
@@ -8,7 +8,7 @@ project(C2A)
 # ！！！注意！！！
 # これをONにした状態で，SCIの受け口がない場合（TMTC IFが動いてない状態）
 # そちらのバッファが詰まってSILSの動作が止まることがあるので注意すること！
-option(USE_SCI_COM_WINGS "Use SCI_COM_WINGS" ON)
+option(C2A_USE_SCI_COM_WINGS "Use SCI_COM_WINGS" ON)
 
 option(C2A_BUILD_WITH_SILS_MOCKUP "Build C2A with SILS mockup for check undefined symbols by build minimal C2A user executable(C89 only)" OFF)
 

--- a/examples/subobc/CMakeLists.txt
+++ b/examples/subobc/CMakeLists.txt
@@ -10,7 +10,7 @@ project(C2A)
 # そちらのバッファが詰まってSILSの動作が止まることがあるので注意すること！
 option(USE_SCI_COM_WINGS "Use SCI_COM_WINGS" ON)
 
-option(USE_SILS_MOCKUP "Use SILS mockup for build C2A with minimal user in C89 only" OFF)
+option(C2A_BUILD_WITH_SILS_MOCKUP "Build C2A with SILS mockup for check undefined symbols by build minimal C2A user executable(C89 only)" OFF)
 
 option(C2A_BUILD_FOR_SILS "Build C2A for SILS target" ON)
 
@@ -18,7 +18,7 @@ option(C2A_BUILD_FOR_SILS "Build C2A for SILS target" ON)
 set(C2A_USE_ALL_CORE_APPS OFF)
 set(C2A_USE_ALL_CORE_TEST_APPS OFF)
 
-if(USE_SILS_MOCKUP)
+if(C2A_BUILD_WITH_SILS_MOCKUP)
   set(C2A_BUILD_AS_CXX OFF)
 endif()
 
@@ -72,7 +72,7 @@ if(C2A_BUILD_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)  # C++
 endif()
 
-if(USE_SILS_MOCKUP)
+if(C2A_BUILD_WITH_SILS_MOCKUP)
   add_definitions(-DDEFINE_MAIN_ON_SILS)
   add_executable(${PROJECT_NAME} ${C2A_SRCS})
 else()

--- a/examples/subobc/CMakeLists.txt
+++ b/examples/subobc/CMakeLists.txt
@@ -32,9 +32,8 @@ set(C2A_USER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/src_user)
 include_directories(src)
 
 # Output debug print to SILS console window
-option(SHOW_DEBUG_PRINT_ON_SILS "Show debug print")
-set(SHOW_DEBUG_PRINT_ON_SILS ON)
-if(SHOW_DEBUG_PRINT_ON_SILS)
+option(C2A_SHOW_DEBUG_PRINT_ON_SILS "Show debug print" ON)
+if(C2A_SHOW_DEBUG_PRINT_ON_SILS)
   add_definitions(-DSHOW_DEBUG_PRINT_ON_SILS)
   message("Show debug print")
 endif()

--- a/examples/subobc/build.rs
+++ b/examples/subobc/build.rs
@@ -6,7 +6,7 @@ fn main() {
         .define("C2A_BUILD_FOR_32BIT", "ON")
         .define("C2A_BUILD_AS_C99", "ON")
         .define("C2A_BUILD_FOR_SILS ", "ON")
-        .define("USE_SCI_COM_WINGS", "OFF")
+        .define("C2A_USE_SCI_COM_WINGS", "OFF")
         .build_target("C2A");
 
     println!("cargo:rerun-if-changed=./CMakeLists.txt");

--- a/examples/subobc/src/src_user/hal/CMakeLists.txt
+++ b/examples/subobc/src/src_user/hal/CMakeLists.txt
@@ -7,7 +7,7 @@ set(C2A_COMMON_SRCS
 )
 
 # 通常，S2EではC++ビルドされるが，C2A core開発のため，C2A単体をC89でライブラリビルドする場合は，mockupをビルド対象にする
-if(USE_SILS_MOCKUP)
+if(C2A_BUILD_WITH_SILS_MOCKUP)
   message("USE SILS_MOCKUP")
 
   #target_sources(${PROJECT_NAME} PRIVATE

--- a/examples/subobc/src/src_user/hal/CMakeLists.txt
+++ b/examples/subobc/src/src_user/hal/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
     sils/wdt_sils.cpp
   )
 
-  if(USE_SCI_COM_WINGS) # TODO: これ USE_SCI_COM_UART では？
+  if(C2A_USE_SCI_COM_WINGS) # TODO: これ USE_SCI_COM_UART では？
     add_definitions(-DUSE_SCI_COM_WINGS)
     #target_sources(${PROJECT_NAME} PUBLIC
     set(C2A_HAL_COM_UART_SRCS

--- a/examples/subobc/src/src_user/hal/CMakeLists.txt
+++ b/examples/subobc/src/src_user/hal/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
     sils/wdt_sils.cpp
   )
 
-  if(C2A_USE_SCI_COM_WINGS) # TODO: これ USE_SCI_COM_UART では？
+  if(C2A_USE_SCI_COM_WINGS) # option 名が confusing だが，subobc の upstream（単体試験では WINGS と疎通するポート）は UART
     add_definitions(-DUSE_SCI_COM_WINGS)
     #target_sources(${PROJECT_NAME} PUBLIC
     set(C2A_HAL_COM_UART_SRCS


### PR DESCRIPTION
## 概要
#86 に引き続き，C2A user 側の CMake option についても整理する

## Issue / PR
- #83 
- #86 

## 詳細
各 C2A user で実際にどのような CMake option が定義されているかは未知だが，#86 でコーディング規約を変更したため，コーディング規約に遵守している限りは，最低限 大文字の SNAKE_CASE で，`C2A_` prefix に揃えているはず．
この PR では，example user の CMake option を新しい規約に遵守させる．

## 検証結果
test へのリンクや，検証結果へのリンク

## 影響範囲
- C2A user 固有の CMake option を指定してビルドしている場合に対して breaking（workflows-c2a など）
- example user は C2A user のテンプレートとして用いられているため，各 C2A user には基本的にこの PR で変更する option が含まれているはず．この PR はそれらの option についての変更先の名前の標準的な命名を推奨する意味も持つ．