### PR TITLE
sils-runtime: require c2a-core v4

### DIFF
--- a/sils-runtime/Cargo.toml
+++ b/sils-runtime/Cargo.toml
@@ -9,4 +9,4 @@ test = false   # 呼んでいる C2A の関数をリンクできないので，u
 # TODO: 適切な c2a-core とマッチした example user をリンクしたテスト
 
 [dependencies]
-c2a-core.workspace = true
+c2a-core = "4"


### PR DESCRIPTION
## 概要
`c2a-sils-runtime` crate で要求する `c2a-core`（crate）のバージョン指定を major version のみにする


## 詳細
特定の c2a-core minor, patch version によらずに `c2a-sils-runtime` crate を使えるようになる

## 検証結果
CI が通ればよし

## 影響範囲
これにより，`c2a-sils-runtime` crate で bindgen 経由で用いている C2A の関数群は major version で維持しなければならないインターフェースとなる（semver のバージョン判断をする API として扱うことになる）

## 補足
beta release は major version のみの指定では扱えないので，v4.0.0 のリリース以降