### PR TITLE
c2a-core hal crates: require c2a-core v4

### DIFF
--- a/hal/i2c-noop/Cargo.toml
+++ b/hal/i2c-noop/Cargo.toml
@@ -5,4 +5,4 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
-c2a-core.workspace = true
+c2a-core = "4"

--- a/hal/spi-noop/Cargo.toml
+++ b/hal/spi-noop/Cargo.toml
@@ -5,4 +5,4 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
-c2a-core.workspace = true
+c2a-core = "4"

--- a/hal/uart-kble/Cargo.toml
+++ b/hal/uart-kble/Cargo.toml
@@ -5,7 +5,7 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
-c2a-core.workspace = true
+c2a-core = "4"
 once_cell = "1"
 futures = "0.3"
 kble-socket = { version = "0.2.0", features = ["axum"] }
@@ -14,4 +14,4 @@ axum = { version = "0.6", default-features = false, features = ["tokio", "http1"
 anyhow = "1"
 
 [dev-dependencies]
-c2a-core = { workspace = true, features = ["no-c2a-link"] }
+c2a-core = { version = "4", features = ["no-c2a-link"] }

--- a/hal/uart-noop/Cargo.toml
+++ b/hal/uart-noop/Cargo.toml
@@ -5,4 +5,4 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
-c2a-core.workspace = true
+c2a-core = "4"

--- a/hal/wdt-noop/Cargo.toml
+++ b/hal/wdt-noop/Cargo.toml
@@ -5,4 +5,4 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
-c2a-core.workspace = true
+c2a-core = "4"


### PR DESCRIPTION
## 概要
#133 と同様に，`hal` の各 crate で要求する `c2a-core`（crate）のバージョン指定を major version のみにする


## 詳細
特定の c2a-core minor, patch version によらずに c2a-core hal の crate を使えるようになる

## 検証結果
CI が通ればよし

## 影響範囲
これにより，c2a-core hal crate で bindgen 経由で用いている C2A の関数群は major version で維持しなければならないインターフェースとなる（semver のバージョン判断をする API として扱うことになる）

## 補足
beta release は major version のみの指定では扱えないので，v4.0.0 のリリース以降