### PR TITLE
Pre Release (v4.0.0-beta.3): Change C2A_USE_SCI_COM_WINGS default OFF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
   - import したバージョン: [ut-issl/c2a-enum-loader ae-v2.0.0](https://github.com/ut-issl/c2a-enum-loader/releases/tag/ae-v2.0.0)
 - [ut-issl/c2a-tlm-cmd-code-generator](https://github.com/ut-issl/c2a-tlm-cmd-code-generator) を c2a-core リポジトリで管理するように変更: [#111](https://github.com/arkedge/c2a-core/pull/111)
   - import したバージョン: [ut-issl/c2a-tlm-cmd-code-generator ae-v2.0.0](https://github.com/ut-issl/c2a-tlm-cmd-code-generator/releases/tag/ae-v2.0.0)
-- CMake option の整理: [#86](https://github.com/arkedge/c2a-core/pull/86)
+- CMake option の整理: [#83](https://github.com/arkedge/c2a-core/issues/83), [#86](https://github.com/arkedge/c2a-core/pull/86), [#132](https://github.com/arkedge/c2a-core/pull/132), [#139](https://github.com/arkedge/c2a-core/pull/139)
   - `C2A_` prefix に統一した（これはコーディング規約にも追加）
   - 意味が分かりにくい命名の変更，今後 optional としていく挙動を default OFF とした
   - `option()` の挙動はユーザ指定によってかなり変わるため，該当する変更は単なるビルドチェックなどではなくすべて grep して変更すること
@@ -42,6 +42,10 @@
   - `USE_ALL_C2A_CORE_APPS` -> `C2A_USE_ALL_CORE_APPS`
   - `USE_ALL_C2A_CORE_TEST_APPS` -> `C2A_USE_ALL_CORE_TEST_APPS`
   - `USE_ALL_C2A_CORE_LIB` -> `C2A_USE_ALL_CORE_LIB`
+  - `USE_SCI_COM_WINGS` -> `C2A_USE_SCI_COM_WINGS`: 今後 WINGS 向けビルドは optional なものとなるので，default で OFF に変更．使う場合はビルド時に指定するか，S2E user の `CMakeLists.txt` で設定すること
+  - `USE_SCI_COM_UART` -> `C2A_USE_SCI_COM_UART`
+  - `USE_SILS_MOCKUP` -> `C2A_BUILD_WITH_SILS_MOCKUP`
+  - `SHOW_DEBUG_PRINT_ON_SILS` -> `C2A_BUILD_WITH_SILS_MOCKUP`
 
 
 ### Enhancements

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "4.0.0-beta.2"
+version = "4.0.0-beta.3"
 
 [workspace]
 resolver = "2"

--- a/c2a_core_main.h
+++ b/c2a_core_main.h
@@ -10,6 +10,6 @@ void C2A_core_main(void);
 #define C2A_CORE_VER_MAJOR (4)
 #define C2A_CORE_VER_MINOR (0)
 #define C2A_CORE_VER_PATCH (0)
-#define C2A_CORE_VER_PRE   ("beta.2")
+#define C2A_CORE_VER_PRE   ("beta.3")
 
 #endif

--- a/examples/mobc/CMakeLists.txt
+++ b/examples/mobc/CMakeLists.txt
@@ -8,7 +8,7 @@ project(C2A)
 # ！！！注意！！！
 # これをONにした状態で，SCIの受け口がない場合（TMTC IFが動いてない状態）
 # そちらのバッファが詰まってSILSの動作が止まることがあるので注意すること！
-option(C2A_USE_SCI_COM_WINGS "Use SCI_COM_WINGS" ON)
+option(C2A_USE_SCI_COM_WINGS "Use SCI_COM_WINGS" OFF)
 
 # SCI COM for connection to PC UART
 # ！！！注意！！！

--- a/examples/mobc/src/src_user/Test/README.md
+++ b/examples/mobc/src/src_user/Test/README.md
@@ -57,3 +57,7 @@ or
 cd ./test/src_user/applications/user_defined/
 rye run pytest -m real -v test_tlm_mem_dump.py
 ```
+
+## WINGS を使った実行時の補足
+- デフォルトで， WIGNS へのデータ送信が無効となっているため，以下を ON にする必要がある．
+    - https://github.com/arkedge/c2a-core/blob/eba25277c16ed50a79610eb9a34c62317a0e0141/examples/mobc/CMakeLists.txt#L11

--- a/examples/mobc/src/src_user/Test/README.md
+++ b/examples/mobc/src/src_user/Test/README.md
@@ -59,5 +59,5 @@ rye run pytest -m real -v test_tlm_mem_dump.py
 ```
 
 ## WINGS を使った実行時の補足
-- デフォルトで， WIGNS へのデータ送信が無効となっているため，以下を ON にする必要がある．
+- デフォルトで，WINGS へのデータ送信が無効となっているため，以下を ON にする必要がある．
     - https://github.com/arkedge/c2a-core/blob/eba25277c16ed50a79610eb9a34c62317a0e0141/examples/mobc/CMakeLists.txt#L11

--- a/examples/subobc/CMakeLists.txt
+++ b/examples/subobc/CMakeLists.txt
@@ -8,7 +8,7 @@ project(C2A)
 # ！！！注意！！！
 # これをONにした状態で，SCIの受け口がない場合（TMTC IFが動いてない状態）
 # そちらのバッファが詰まってSILSの動作が止まることがあるので注意すること！
-option(C2A_USE_SCI_COM_WINGS "Use SCI_COM_WINGS" ON)
+option(C2A_USE_SCI_COM_WINGS "Use SCI_COM_WINGS" OFF)
 
 option(C2A_BUILD_WITH_SILS_MOCKUP "Build C2A with SILS mockup for check undefined symbols by build minimal C2A user executable(C89 only)" OFF)
 

--- a/examples/subobc/src/src_user/Test/README.md
+++ b/examples/subobc/src/src_user/Test/README.md
@@ -17,8 +17,11 @@ pytest は subobc 側（このディレクトリ）で実行する．
 - SILS 環境 [S2E User for C2A Core](https://github.com/ut-issl/s2e-user-for-c2a-core) を 2 セット準備し， MOBC，AOBC それぞれを立ち上げる．
     - S2E の使い方は S2E Document を参照すること．
     - この時， MOBC の CCSDS ポートは WINGS の仮想ポートに接続（ループバック）し， MOBC の UART ポートは AOBC の UART ポートに接続（ループバック）させる．
+    - MOBC / AOBC 側で WINGS への COM ポートへの出力を有効化するために，以下を ON にする．
+        - https://github.com/arkedge/c2a-core/blob/eba25277c16ed50a79610eb9a34c62317a0e0141/examples/mobc/CMakeLists.txt#L11
+        - https://github.com/arkedge/c2a-core/blob/eba25277c16ed50a79610eb9a34c62317a0e0141/examples/subobc/CMakeLists.txt#L11
     - MOBC 側で AOBC への COM ポートへの出力を有効化するために，以下を ON にする．
-        - https://github.com/arkedge/c2a-core/blob/45d78a05c339c285b5aa0c2fcbf57c1b105137e9/Examples/mobc/CMakeLists.txt#L17
+        - https://github.com/arkedge/c2a-core/blob/eba25277c16ed50a79610eb9a34c62317a0e0141/examples/mobc/CMakeLists.txt#L17
     - デフォルトでは，以下のようになっている．
         - MOBC CCSDS: COM11
         - MOBC UART: COM13


### PR DESCRIPTION
## 概要
C2A user の `C2A_USE_SCI_COM_WINGS` を default OFF にする

## Issue
- #83 

## 詳細
今は Gaia を標準的に使っており，WINGS のためのビルドは optional なものであるため

## 影響範囲
SILS-S2E で WINGS と接続して試験などを行っている場合，最終的なユーザ側（S2E user ないし build option）で明示的にこのオプションを ON に指定してビルドする必要がある．

## 備考
- [x] マージ前にバージョンを上げる
- [ ] リリースを打つ
