### PR TITLE
Drop c2a-core crate links config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,6 @@ name = "c2a-core"
 version.workspace = true
 edition = "2021"
 
-links = "c2a-core"
-
 description = "Core of Command Centric Architecture"
 readme = "README.md"
 license = "MIT"

--- a/build.rs
+++ b/build.rs
@@ -7,8 +7,6 @@ use semver::Version;
 use clang::{token::TokenKind::Punctuation, Clang, Index};
 
 fn main() {
-    println!("cargo:source_dir={}", env!("CARGO_MANIFEST_DIR"));
-
     let ver = env!("CARGO_PKG_VERSION");
     let ver = Version::parse(ver).unwrap();
     dbg!(&ver);


### PR DESCRIPTION
This reverts commit db74c2892b698e24d31a94080a46211e6c664600, reversing changes made to 7497a8e8fc06e9792c07fdd0d3232481ab629b9a.

## 概要
ut-issl/c2a-core#580 を revert する

## Issue / PR
- ut-issl/c2a-core#580

## 詳細
- https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key
- `package.links` は `*-sys` crate のためのもの
  - `c2a-core` は単体ではビルド・リンクできないライブラリなので，このオプションは目的外使用
  - そのため，`package.links` で指定した識別子が複数（バージョン差異も含む）の crate で被ることを想定していない（エラーになる）
    - これは（一つのビルドコンテキスト ≒ C2A user で） `c2a-core` crate を使う crate が複数ある時に問題となる
    - つまり，指定する `c2a-core` crate のバージョンを丁寧に揃える必要がある
    - これは真に同じバージョンである必要があるので，別の branch の実装をちょっと使いたい，みたいな時にも困る
    - また， #133 など（`c2a-core` の major version で維持する API のみに依存させたい）でも困る
- このオプションを使わないと使えない `c2a-core` crate -> user crate build script の変数伝搬機能を使うために ut-issl/c2a-core#580 で導入した
  - この目的は `c2a-core` crate のビルド時のソースファイルディレクトリを取得するため
  - これによるデメリットが大きくなりすぎた & 他の方法でもこの情報は取得可能であるため，revert する

## 検証結果
CI が通ればよし

## 影響範囲
`c2a-core` crate のソースファイルディレクトリを Cargo 経由で公開する機能（breaking change ではあるが，元々まだ example user でも使っていない experimental な機能）