### PR TITLE
More match system migration

### DIFF
--- a/script/migration/v4-rename-system.sh
+++ b/script/migration/v4-rename-system.sh
@@ -41,11 +41,11 @@ mv src/src_user/Settings/system/EventHandlerRules src/src_user/Settings/system/e
 find_settings | xargs -0 sed -i -e "s#System/EventHandlerRules#system/event_handler_rules#g"
 find_settings | xargs -0 sed -i -e "s#System#system#g"
 
-find_all | xargs -0 sed -i -e "s#src_user/Settings/System/EventHandlerRules#src_user/Setting/system/event_handler_rules#g"
-find_all | xargs -0 sed -i -e "s#src_user\\\Settings\\\System\\\EventHandlerRules#src_user\\\Settings\\\system\\\event_handler_rules#g"
+find_all | xargs -0 sed -i -e "s#Settings/System/EventHandlerRules#Setting/system/event_handler_rules#g"
+find_all | xargs -0 sed -i -e "s#Settings\\\System\\\EventHandlerRules#Settings\\\system\\\event_handler_rules#g"
 
-find_all | xargs -0 sed -i -e "s#src_user/Settings/System#src_user/Settings/system#g"
-find_all | xargs -0 sed -i -e "s#src_user\\\Settings\\\System#src_user\\\Settings\\\system#g"
+find_all | xargs -0 sed -i -e "s#Settings/System#Settings/system#g"
+find_all | xargs -0 sed -i -e "s#Settings\\\System#Settings\\\system#g"
 
 # Test
 echo "rename test dir: test/src_core/System -> test/src_core/system"


### PR DESCRIPTION
## 概要
v4.0.0 での System rename migration の不備修整

## 詳細
`#include "../../Settings/System/EventHandlerRules"` などの参照がありえるため，マッチする範囲を拡大した

## 影響範囲
v4 rename System migration（c2a-core v4.0.0-beta.1）