### PR TITLE
Exclude Doxygen stdint_wrapper

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -918,7 +918,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = library/stdint_wrapper/
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded


### PR DESCRIPTION
## 概要
`library/stdint_wrapper` は C89 環境のための特殊な対応なので，Doxygen の生成結果からは排除する

## Issue
- #9 

## 詳細
- そもそも `examples/mobc` では stdint wrapper は使っていないので，中途半端な表示になっている
- `stdint.h` は `stddef.h` などと同等に表示すべき

## 検証結果
これが
![2023-11-10_21-32](https://github.com/arkedge/c2a-core/assets/23310673/92faf0ed-44e6-420e-a071-c5f7c06fbc63)

こうなる
![2023-11-10_21-30](https://github.com/arkedge/c2a-core/assets/23310673/10f5bb51-1a29-4e25-b96f-6fd3d8b607ff)


## 影響範囲
C2A Reference の Doxygen

## 補足
#207 を先にマージする
