### PR TITLE
CCSDS data link layer における SCID をユーザー設定として切り出す

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Enhancements
 
 - [#214](https://github.com/arkedge/c2a-core/pull/214): CCSDS の主 MOBC 向け Data Link Layer のコードを Core 管理にする
+- [#214](https://github.com/arkedge/c2a-core/pull/219): CCSDS の主 MOBC 向け Data Link Layer の SCID をユーザー設定として切り出す
 
 ### Fixed
 
@@ -54,6 +55,8 @@
         - CMake の場合， `C2A_USE_CORE_CCSDS_TC_SPACE_DATA_LINK_PROTOCOL` option を `ON` にするだけでよい (C2A user top の `CMakeLists.txt`)
           - `examples/mobc/CMakeLists.txt` を参考にできる．
      1. コンパイルが通らないところを直す．ファイルの場所が変わったことによる include path の修正が想定される．
+- [#219](https://github.com/arkedge/c2a-core/pull/219): 影響範囲は MOBC のみ
+  1. PR の diff (`examples/mobc/src/`) に出ている修正を， user にも反映させる．
 
 
 ## v4.0.1 (2023-11-09)

--- a/examples/mobc/src/src_user/component_driver/com/gs.c
+++ b/examples/mobc/src/src_user/component_driver/com/gs.c
@@ -84,8 +84,8 @@ CDS_INIT_ERR_CODE GS_init(GS_Driver* gs_driver,
   GS_rx_header_[2][0] |= (uint8_t)((TCTF_TYPE_BC & 0x0f) << 4);
   for (stream = 0; stream < GS_RX_HEADER_NUM; ++stream)
   {
-    GS_rx_header_[stream][0] |= (uint8_t)((TCTF_SCID_SAMPLE_SATELLITE & 0x3ff) >> 8);
-    GS_rx_header_[stream][1] |= (uint8_t)(TCTF_SCID_SAMPLE_SATELLITE & 0xff);
+    GS_rx_header_[stream][0] |= (uint8_t)((TCTD_SCID_MY_ID & 0x3ff) >> 8);
+    GS_rx_header_[stream][1] |= (uint8_t)(TCTD_SCID_MY_ID & 0xff);
   }
 
   ret_ccsds = CDS_init_streams(&gs_driver->driver_ccsds.super,

--- a/examples/mobc/src/src_user/component_driver/com/gs_validate.c
+++ b/examples/mobc/src/src_user/component_driver/com/gs_validate.c
@@ -84,7 +84,7 @@ GS_VALIDATE_ERR GS_validate_tctf(const TcTransferFrame* tctf)
 static GS_VALIDATE_ERR GS_check_tctf_header_(const TcTransferFrame* tctf)
 {
   if (TCTF_get_ver(tctf) != TCTF_VER_1) return GS_VALIDATE_ERR_TCTF_VER;
-  if (TCTF_get_scid(tctf) != TCTF_SCID_SAMPLE_SATELLITE) return GS_VALIDATE_ERR_TCTF_SCID;
+  if (TCTF_get_scid(tctf) != TCTD_SCID_MY_ID) return GS_VALIDATE_ERR_TCTF_SCID;
   if (TCTF_get_vcid(tctf) != TCTF_VCID_REALTIME) return GS_VALIDATE_ERR_TCTF_VCID;
 
   return GS_VALIDATE_ERR_OK;

--- a/examples/mobc/src/src_user/settings/CMakeLists.txt
+++ b/examples/mobc/src/src_user/settings/CMakeLists.txt
@@ -17,7 +17,9 @@ set(C2A_SRCS
   system/event_handler_rules/event_handler_rules.c
   system/event_handler_rules/event_handler_rule_test.c
   tlm_cmd/common_cmd_packet_define.c
+  tlm_cmd/ccsds/aos_transfer_frame_define.c
   tlm_cmd/ccsds/apid_define.c
+  tlm_cmd/ccsds/tc_transfer_frame_define.c
 )
 
 if(C2A_BUILD_AS_CXX)

--- a/examples/mobc/src/src_user/settings/tlm_cmd/ccsds/aos_transfer_frame_define.c
+++ b/examples/mobc/src/src_user/settings/tlm_cmd/ccsds/aos_transfer_frame_define.c
@@ -1,0 +1,19 @@
+#pragma section REPRO
+/**
+ * @file
+ * @brief AOS Transfer Frame のユーザー定義
+ */
+#include "aos_transfer_frame_define.h"
+
+AOSTF_SCID AOSTF_get_scid_from_uint8(uint8_t scid)
+{
+  switch ((AOSTF_SCID)scid)
+  {
+  case AOSTF_SCID_SAMPLE_SATELLITE:
+    return (AOSTF_SCID)scid;
+  default:
+    return AOSTF_SCID_UNKNOWN;
+  }
+}
+
+#pragma section

--- a/examples/mobc/src/src_user/settings/tlm_cmd/ccsds/aos_transfer_frame_define.h
+++ b/examples/mobc/src/src_user/settings/tlm_cmd/ccsds/aos_transfer_frame_define.h
@@ -1,0 +1,32 @@
+/**
+ * @file
+ * @brief AOS Transfer Frame のユーザー定義
+ * @note  aos_transfer_frame.h などから include されることを前提
+ */
+#ifndef AOS_TRANSFER_FRAME_DEFINE_H_
+#define AOS_TRANSFER_FRAME_DEFINE_H_
+
+#include <stdint.h>
+
+/**
+ * @enum  AOSTF_SCID
+ * @brief Spacecraft ID
+ * @note  8 bit
+ */
+typedef enum
+{
+  AOSTF_SCID_SAMPLE_SATELLITE = 0x00,
+  AOSTF_SCID_UNKNOWN
+} AOSTF_SCID;
+
+#define AOSTF_SCID_MY_ID  (AOSTF_SCID_SAMPLE_SATELLITE)   //!< 自分の SCID
+
+/**
+ * @brief  バイト列から AOSTF_SCID を取得
+ * @param  scid: AOSTF_SCID 候補の uint8_t
+ * @note   不正な入力のときは AOSTF_SCID_UNKNOWN を返す
+ * @return AOSTF_SCID
+ */
+AOSTF_SCID AOSTF_get_scid_from_uint8(uint8_t scid);
+
+#endif

--- a/examples/mobc/src/src_user/settings/tlm_cmd/ccsds/tc_transfer_frame_define.c
+++ b/examples/mobc/src/src_user/settings/tlm_cmd/ccsds/tc_transfer_frame_define.c
@@ -1,0 +1,19 @@
+#pragma section REPRO
+/**
+ * @file
+ * @brief TC Transfer Frame のユーザー定義
+ */
+#include "tc_transfer_frame_define.h"
+
+TCTF_SCID TCTF_get_scid_from_uint16(uint16_t scid)
+{
+  switch ((TCTF_SCID)scid)
+  {
+  case TCTF_SCID_SAMPLE_SATELLITE:
+    return (TCTF_SCID)scid;
+  default:
+    return TCTF_SCID_UNKNOWN;
+  }
+}
+
+#pragma section

--- a/examples/mobc/src/src_user/settings/tlm_cmd/ccsds/tc_transfer_frame_define.h
+++ b/examples/mobc/src/src_user/settings/tlm_cmd/ccsds/tc_transfer_frame_define.h
@@ -1,0 +1,32 @@
+/**
+ * @file
+ * @brief TC Transfer Frame のユーザー定義
+ * @note  tc_transfer_frame.h などから include されることを前提
+ */
+#ifndef TC_TRANSFER_FRAME_DEFINE_H_
+#define TC_TRANSFER_FRAME_DEFINE_H_
+
+#include <stdint.h>
+
+/**
+ * @enum  TCTF_SCID
+ * @brief Spacecraft ID
+ * @note  10 bit
+ */
+typedef enum
+{
+  TCTF_SCID_SAMPLE_SATELLITE = 0x157, // SCID for command of sample satellite
+  TCTF_SCID_UNKNOWN
+} TCTF_SCID;
+
+#define TCTD_SCID_MY_ID (TCTF_SCID_SAMPLE_SATELLITE)    //!< 自分の SCID
+
+/**
+ * @brief  バイト列から TCTF_SCID を取得
+ * @param  scid: TCTF_SCID 候補の uint16_t
+ * @note   不正な入力のときは TCTF_SCID_UNKNOWN を返す
+ * @return TCTF_SCID
+ */
+TCTF_SCID TCTF_get_scid_from_uint16(uint16_t scid);
+
+#endif

--- a/tlm_cmd/ccsds/aos_space_data_link_protocol/aos_transfer_frame.c
+++ b/tlm_cmd/ccsds/aos_space_data_link_protocol/aos_transfer_frame.c
@@ -47,7 +47,7 @@ void AOSTF_setup_replay_aostf_hdr(AosTransferFrame* aostf, uint32_t counter)
 static void AOSTF_set_common_hdr_(AosTransferFrame* aostf)
 {
   AOSTF_set_ver(aostf, AOSTF_VER_2);
-  AOSTF_set_scid(aostf, AOSTF_SCID_SAMPLE_SATELLITE); // FIXME: 仮
+  AOSTF_set_scid(aostf, AOSTF_SCID_MY_ID);
   AOSTF_set_replay_flag(aostf, AOSTF_REPLAY_FALSE);
   AOSTF_clear_spare_(aostf);
 }
@@ -96,13 +96,7 @@ AOSTF_SCID AOSTF_get_scdi(const AosTransferFrame* aostf)
   scid <<= 2;
   scid |= ((aostf->header[pos + 1] & mask2) >> 6);
 
-  switch (scid)
-  {
-  case AOSTF_SCID_SAMPLE_SATELLITE:
-    return (AOSTF_SCID)scid;
-  default:
-    return AOSTF_SCID_UNKNOWN;
-  }
+  return AOSTF_get_scid_from_uint8((uint8_t)scid);
 }
 
 void AOSTF_set_scid(AosTransferFrame* aostf, AOSTF_SCID scid)

--- a/tlm_cmd/ccsds/aos_space_data_link_protocol/aos_transfer_frame.h
+++ b/tlm_cmd/ccsds/aos_space_data_link_protocol/aos_transfer_frame.h
@@ -47,6 +47,17 @@
 #define AOSTF_LEN           (AOSTF_HEADER_SIZE + M_PDU_LEN + AOSTF_TRAILER_SIZE)
 #define AOSTF_COUNTER_MAX   (0x01000000) // 24bit長
 
+// ここで AOSTF_SCID, AOSTF_SCID_MY_ID を定義する
+// AOSTF_SCID_UNKNOWN は必須
+/* 例
+typedef enum
+{
+  AOSTF_SCID_SAMPLE_SATELLITE = 0x00,
+  AOSTF_SCID_UNKNOWN
+} AOSTF_SCID;
+*/
+#include <src_user/settings/tlm_cmd/ccsds/aos_transfer_frame_define.h>
+
 typedef struct
 {
   uint8_t                      header[AOSTF_HEADER_SIZE];
@@ -59,12 +70,6 @@ typedef enum
   AOSTF_VER_2 = 1, // 01b: Version2
   AOSTF_VER_UNKNOWN
 } AOSTF_VER;
-
-typedef enum
-{
-  AOSTF_SCID_SAMPLE_SATELLITE = 0x00,
-  AOSTF_SCID_UNKNOWN
-} AOSTF_SCID;
 
 typedef enum
 {

--- a/tlm_cmd/ccsds/tc_space_data_link_protocol/tc_transfer_frame.c
+++ b/tlm_cmd/ccsds/tc_space_data_link_protocol/tc_transfer_frame.c
@@ -50,18 +50,11 @@ TCTF_SCID TCTF_get_scid(const TcTransferFrame* tctf)
   uint8_t mask = 0x03; // 0000 0011b
 
   // pos = 0の下位2bitsとpos = 1の8bitsを合わせた10bits
-  TCTF_SCID scid = (TCTF_SCID)(tctf->packet[pos] & mask);
-  scid = (TCTF_SCID)(scid << 8);
-  scid = (TCTF_SCID)(scid + tctf->packet[pos + 1]);
+  uint16_t scid = (uint16_t)(tctf->packet[pos] & mask);
+  scid = (uint16_t)(scid << 8);
+  scid = (uint16_t)(scid + tctf->packet[pos + 1]);
 
-  switch (scid)
-  {
-  case TCTF_SCID_SAMPLE_SATELLITE:
-    return scid;
-
-  default:
-    return TCTF_SCID_UNKNOWN;
-  }
+  return TCTF_get_scid_from_uint16(scid);
 }
 
 TCTF_VCID TCTF_get_vcid(const TcTransferFrame* tctf)

--- a/tlm_cmd/ccsds/tc_space_data_link_protocol/tc_transfer_frame.h
+++ b/tlm_cmd/ccsds/tc_space_data_link_protocol/tc_transfer_frame.h
@@ -45,6 +45,17 @@
 #error TCTCF LEN IS LONGER THAN TCTF MAX LEN
 #endif
 
+// ここで TCTF_SCID, TCTD_SCID_MY_ID を定義する
+// TCTF_SCID_UNKNOWN は必須
+/* 例
+typedef enum
+{
+  TCTF_SCID_SAMPLE_SATELLITE = 0x000,
+  TCTF_SCID_UNKNOWN
+} TCTF_SCID;
+*/
+#include <src_user/settings/tlm_cmd/ccsds/tc_transfer_frame_define.h>
+
 /**
  * @struct TcTransferFrame
  * @brief  TC Transfer Frame のパケット構造体
@@ -77,17 +88,6 @@ typedef enum
   TCTF_TYPE_BC = 3, // 11b: FARM Control Command
   TCTF_TYPE_UNKNOWN
 } TCTF_TYPE;
-
-/**
- * @enum  TCTF_SCID
- * @brief Spacecraft ID
- * @note  10 bit
- */
-typedef enum
-{
-  TCTF_SCID_SAMPLE_SATELLITE = 0x157, // SCID for command of sample satellite
-  TCTF_SCID_UNKNOWN
-} TCTF_SCID;
 
 /**
  * @enum  TCTF_VCID


### PR DESCRIPTION
## 概要
AOSTF, TCTF の SCID を user settings に切り出す．
APID と同様の形に

## Issue
- https://github.com/arkedge/c2a-core/issues/196
- https://github.com/arkedge/c2a-core/issues/190

## 詳細
- https://github.com/arkedge/c2a-core/pull/214 の続き

## 残作業
- [x] change log 書く