### PR TITLE
APIDの命名規則の更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [#214](https://github.com/arkedge/c2a-core/pull/214): CCSDS の主 MOBC 向け Data Link Layer のコードを Core 管理にする
 - [#214](https://github.com/arkedge/c2a-core/pull/219): CCSDS の主 MOBC 向け Data Link Layer の SCID をユーザー設定として切り出す
+- [#220](https://github.com/arkedge/c2a-core/pull/220): APID の命名規則を策定 (命名規則は `tlm_cmd/common_tlm_cmd_packet.h` を参照)
 
 ### Fixed
 
@@ -57,6 +58,8 @@
      1. コンパイルが通らないところを直す．ファイルの場所が変わったことによる include path の修正が想定される．
 - [#219](https://github.com/arkedge/c2a-core/pull/219): 影響範囲は MOBC のみ
   1. PR の diff (`examples/mobc/src/`) に出ている修正を， user にも反映させる．
+- [#220](https://github.com/arkedge/c2a-core/pull/220)
+  1. `tlm_cmd/common_tlm_cmd_packet.h` にある命名規則に従うように， APID の命名を更新する．
 
 
 ## v4.0.1 (2023-11-09)

--- a/docs/core/communication.md
+++ b/docs/core/communication.md
@@ -166,13 +166,13 @@ https://github.com/arkedge/c2a-core/blob/45d78a05c339c285b5aa0c2fcbf57c1b105137e
     - BC: GS から MOBC に届き， MOBC で BC 登録されずに，そのまま AOBC へ配送される．配送時， Destination Type は自分宛 (TO_ME) に上書きされ， AOBC で BC として登録 & 実行される．
 - 地上局 SW での実装まとめ
   - MOBC 宛
-    - APID: APID_MOBC_CMD
+    - APID: APID_CMD_TO_MOBC
     - CCP_DEST_TYPE: CCP_DEST_TYPE_TO_ME
   - AOBC 宛（AOBC 直送）
-    - APID: APID_AOBC_CMD
+    - APID: APID_CMD_TO_AOBC
     - CCP_DEST_TYPE: CCP_DEST_TYPE_TO_AOBC
   - AOBC 宛（MOBC でキューに入り，実行時に AOBC に転送）
-    - APID: APID_AOBC_CMD
+    - APID: APID_CMD_TO_AOBC
     - CCP_DEST_TYPE: CCP_DEST_TYPE_TO_ME
 
 

--- a/examples/mobc/src/src_user/component_driver/com/gs_validate.c
+++ b/examples/mobc/src/src_user/component_driver/com/gs_validate.c
@@ -139,9 +139,9 @@ static GS_VALIDATE_ERR GS_check_cmd_space_packet_headers_(const CmdSpacePacket* 
   }
 
   apid = CSP_get_apid(csp);
-  if ( !( apid == APID_MOBC_CMD ||
-          apid == APID_AOBC_CMD ||
-          apid == APID_TOBC_CMD ) )
+  if ( !( apid == APID_CMD_TO_MOBC ||
+          apid == APID_CMD_TO_AOBC ||
+          apid == APID_CMD_TO_TOBC ) )
   {
     return GS_VALIDATE_ERR_APID;
   }

--- a/examples/mobc/src/src_user/settings/tlm_cmd/ccsds/apid_define.c
+++ b/examples/mobc/src/src_user/settings/tlm_cmd/ccsds/apid_define.c
@@ -11,14 +11,14 @@ APID APID_get_apid_from_uint16(uint16_t apid)
 {
   switch ((APID)apid)
   {
-  case APID_MOBC_CMD:   // FALLTHROUGH
-  case APID_AOBC_CMD:   // FALLTHROUGH
-  case APID_TOBC_CMD:   // FALLTHROUGH
-  case APID_TCAL_TLM:   // FALLTHROUGH
-  case APID_MOBC_TLM:   // FALLTHROUGH
-  case APID_AOBC_TLM:   // FALLTHROUGH
-  case APID_TOBC_TLM:   // FALLTHROUGH
-  case APID_DUMP_TLM:   // FALLTHROUGH
+  case APID_CMD_TO_MOBC:  // FALLTHROUGH
+  case APID_CMD_TO_AOBC:  // FALLTHROUGH
+  case APID_CMD_TO_TOBC:  // FALLTHROUGH
+  case APID_TLM_TCAL:     // FALLTHROUGH
+  case APID_TLM_MOBC:     // FALLTHROUGH
+  case APID_TLM_AOBC:     // FALLTHROUGH
+  case APID_TLM_TOBC:     // FALLTHROUGH
+  case APID_TLM_DUMP:     // FALLTHROUGH
   case APID_FILL_PKT:
     return (APID)apid;
 

--- a/examples/mobc/src/src_user/settings/tlm_cmd/ccsds/apid_define.h
+++ b/examples/mobc/src/src_user/settings/tlm_cmd/ccsds/apid_define.h
@@ -12,18 +12,7 @@
  * @enum   APID
  * @brief  Application Process ID
  * @note   11bit
- * @note   命名規則:
- *           Tlm: APID_TLM_{送信元}_TO_{受信先}_VIA_{経由地}
- *           Cmd: APID_CMD_{送信元}_TO_{受信先}_VIA_{経由地}
- *           ただし，Tlm の TO_SGS，Cmd の SGS は省略できる
- *           例:
- *             APID_CMD_TO_MOBC (SGS を省略)
- *             APID_TLM_AOBC (TO_SGS を省略．パスが単一しかありえないので， VIA_MOBCも省略)
- *             APID_TLM_CAMERA_TO_XGS_VIA_MIF (全部記載)
- *           注意:
- *             同一コンポからアプリケーション等を区別して APID を発行したい場合 (eg; HK テレメ，ミッションデータ，Sバンドデータ，X バンドデータ，など) は {送信元} にそれを識別する命名ができる
- *             APID_TLM_AOBC, APID_TLM_AOBC_STT_IMG, など
- *           詳細: https://github.com/arkedge/c2a-core/issues/186#issuecomment-1798685321
+ * @note   命名規則は tlm_cmd/common_tlm_cmd_packet.h を参照
  */
 typedef enum
 {

--- a/examples/mobc/src/src_user/settings/tlm_cmd/ccsds/apid_define.h
+++ b/examples/mobc/src/src_user/settings/tlm_cmd/ccsds/apid_define.h
@@ -12,18 +12,30 @@
  * @enum   APID
  * @brief  Application Process ID
  * @note   11bit
+ * @note   命名規則:
+ *           Tlm: APID_TLM_{送信元}_TO_{受信先}_VIA_{経由地}
+ *           Cmd: APID_CMD_{送信元}_TO_{受信先}_VIA_{経由地}
+ *           ただし，Tlm の TO_SGS，Cmd の SGS は省略できる
+ *           例:
+ *             APID_CMD_TO_MOBC (SGS を省略)
+ *             APID_TLM_AOBC (TO_SGS を省略．パスが単一しかありえないので， VIA_MOBCも省略)
+ *             APID_TLM_CAMERA_TO_XGS_VIA_MIF (全部記載)
+ *           注意:
+ *             同一コンポからアプリケーション等を区別して APID を発行したい場合 (eg; HK テレメ，ミッションデータ，Sバンドデータ，X バンドデータ，など) は {送信元} にそれを識別する命名ができる
+ *             APID_TLM_AOBC, APID_TLM_AOBC_STT_IMG, など
+ *           詳細: https://github.com/arkedge/c2a-core/issues/186#issuecomment-1798685321
  */
 typedef enum
 {
-  APID_MOBC_CMD = 0x210,    //!< 01000010000b: APID for MOBC 宛の CMD
-  APID_AOBC_CMD = 0x211,    //!< 01000010001b: APID for AOBC 宛の CMD
-  APID_TOBC_CMD = 0x212,    //!< 01000010010b: APID for TOBC 宛の CMD
-  APID_TCAL_TLM = 0x410,    //!< 10000010000b: APID for TIME CARIBLATION TLM (FIXME: 現在まともに使ってない)
-  APID_MOBC_TLM = 0x510,    //!< 10100010000b: APID for MOBC で生成される TLM
-  APID_AOBC_TLM = 0x511,    //!< 10100010001b: APID for AOBC で生成される TLM
-  APID_TOBC_TLM = 0x512,    //!< 10100010002b: APID for TOBC で生成される TLM
-  APID_DUMP_TLM = 0x710,    //!< 11100010000b: APID for DUMP TLM (FIXME: 現在まともに使ってない)
-  APID_FILL_PKT = 0x7ff,    //!< 11111111111b: APID for FILL PACKET
+  APID_CMD_TO_MOBC = 0x210,   //!< 01000010000b: APID for MOBC 宛の CMD
+  APID_CMD_TO_AOBC = 0x211,   //!< 01000010001b: APID for AOBC 宛の CMD
+  APID_CMD_TO_TOBC = 0x212,   //!< 01000010010b: APID for TOBC 宛の CMD
+  APID_TLM_TCAL = 0x410,      //!< 10000010000b: APID for TIME CARIBLATION TLM (FIXME: 現在まともに使ってない)
+  APID_TLM_MOBC = 0x510,      //!< 10100010000b: APID for MOBC で生成される TLM
+  APID_TLM_AOBC = 0x511,      //!< 10100010001b: APID for AOBC で生成される TLM
+  APID_TLM_TOBC = 0x512,      //!< 10100010002b: APID for TOBC で生成される TLM
+  APID_TLM_DUMP = 0x710,      //!< 11100010000b: APID for DUMP TLM (FIXME: 現在まともに使ってない)
+  APID_FILL_PKT = 0x7ff,      //!< 11111111111b: APID for FILL PACKET
   APID_UNKNOWN
 } APID;
 

--- a/examples/mobc/src/src_user/settings/tlm_cmd/common_cmd_packet_define.h
+++ b/examples/mobc/src/src_user/settings/tlm_cmd/common_cmd_packet_define.h
@@ -15,7 +15,7 @@ typedef CmdSpacePacket CommonCmdPacket;
 
 // 自分宛て CMD を示す AIPD を定義
 // FIXME: Space Packet が整備されたら直す
-#define CCP_APID_TO_ME (APID_MOBC_CMD)
+#define CCP_APID_CMD_TO_ME (APID_MOBC_CMD)
 
 /**
  * @enum   CCP_DEST_TYPE

--- a/examples/mobc/src/src_user/settings/tlm_cmd/common_cmd_packet_define.h
+++ b/examples/mobc/src/src_user/settings/tlm_cmd/common_cmd_packet_define.h
@@ -15,7 +15,7 @@ typedef CmdSpacePacket CommonCmdPacket;
 
 // 自分宛て CMD を示す AIPD を定義
 // FIXME: Space Packet が整備されたら直す
-#define CCP_APID_CMD_TO_ME (APID_MOBC_CMD)
+#define CCP_APID_CMD_TO_ME (APID_CMD_TO_MOBC)
 
 /**
  * @enum   CCP_DEST_TYPE

--- a/examples/mobc/src/src_user/settings/tlm_cmd/common_tlm_packet_define.h
+++ b/examples/mobc/src/src_user/settings/tlm_cmd/common_tlm_packet_define.h
@@ -15,6 +15,6 @@ typedef TlmSpacePacket CommonTlmPacket;
 
 // 自分で生成される TLM を示す AIPD を定義
 // FIXME: Space Packet が整備されたら直す
-#define CTP_APID_FROM_ME (APID_MOBC_TLM)
+#define CTP_APID_TLM_FROM_ME (APID_MOBC_TLM)
 
 #endif

--- a/examples/mobc/src/src_user/settings/tlm_cmd/common_tlm_packet_define.h
+++ b/examples/mobc/src/src_user/settings/tlm_cmd/common_tlm_packet_define.h
@@ -15,6 +15,6 @@ typedef TlmSpacePacket CommonTlmPacket;
 
 // 自分で生成される TLM を示す AIPD を定義
 // FIXME: Space Packet が整備されたら直す
-#define CTP_APID_TLM_FROM_ME (APID_MOBC_TLM)
+#define CTP_APID_TLM_FROM_ME (APID_TLM_MOBC)
 
 #endif

--- a/examples/mobc/src/src_user/tlm_cmd/normal_block_command_definition/nbc_test_bcl.c
+++ b/examples/mobc/src/src_user/tlm_cmd/normal_block_command_definition/nbc_test_bcl.c
@@ -31,7 +31,7 @@ void BCL_load_test_bcl(void)
   // other_obc コマンドのチェック
   // FIXME: other OBC のコマンド数が 本OBC より多くなるとキャストできなくて困る
   BCL_tool_prepare_param_uint8(3);
-  BCL_tool_register_cmd_to_other_obc(5, APID_AOBC_CMD, (CMD_CODE)AOBC_Cmd_CODE_MM_START_TRANSITION);
+  BCL_tool_register_cmd_to_other_obc(5, APID_CMD_TO_AOBC, (CMD_CODE)AOBC_Cmd_CODE_MM_START_TRANSITION);
 }
 
 #pragma section

--- a/examples/mobc/src/src_user/tlm_cmd/user_packet_handler.c
+++ b/examples/mobc/src/src_user/tlm_cmd/user_packet_handler.c
@@ -39,12 +39,12 @@ PH_ACK PH_user_analyze_cmd(const CommonCmdPacket* packet)
   {
     switch (apid)
     {
-    case APID_AOBC_CMD:
+    case APID_CMD_TO_AOBC:
       return (PH_add_aobc_cmd_(packet) == PH_ACK_SUCCESS) ? PH_ACK_FORWARDED : PH_ACK_PL_LIST_FULL;
-    case APID_TOBC_CMD:
+    case APID_CMD_TO_TOBC:
       return (PH_add_tobc_cmd_(packet) == PH_ACK_SUCCESS) ? PH_ACK_FORWARDED : PH_ACK_PL_LIST_FULL;
     default:
-      // APID_MOBC_CMD
+      // APID_CMD_TO_MOBC
       // 不正な APID
       // はここに
       return PH_ACK_UNKNOWN;
@@ -74,10 +74,10 @@ CCP_CmdRet PH_user_cmd_router(const CommonCmdPacket* packet)
   APID apid = CCP_get_apid(packet);
   switch (apid)
   {
-  case APID_AOBC_CMD:
+  case APID_CMD_TO_AOBC:
     // AOBCに配送
     return CSRV_AOBC_dispatch_command(packet);
-  case APID_TOBC_CMD:
+  case APID_CMD_TO_TOBC:
     // TOBCに配送
     // return CSRV_TOBC_dispatch_command(packet);
   default:
@@ -95,7 +95,7 @@ TF_TLM_FUNC_ACK PH_user_telemetry_router(APID apid,
 {
   switch (apid)
   {
-    case APID_AOBC_TLM:
+    case APID_TLM_AOBC:
       return AOBC_pick_up_tlm_buffer(aobc_driver, (AOBC_TLM_CODE)tlm_id, packet, len, max_len);
     default:
       return TF_TLM_FUNC_ACK_NOT_DEFINED;

--- a/examples/subobc/src/src_user/applications/component_service/csrv_mobc.c
+++ b/examples/subobc/src/src_user/applications/component_service/csrv_mobc.c
@@ -112,8 +112,8 @@ static RESULT CSRV_MOBC_rt_tlm_packet_handler_(void)
     PL_drop_executed(&PH_rt_tlm_list);
 
     // FIXME: 現状，WINGS の問題から DUMP TLMは考えない．
-    //        APID_AOBC_TLM 以外を弾いている．
-    if (CTP_get_apid(&packet) != APID_AOBC_TLM)
+    //        APID_TLM_AOBC 以外を弾いている．
+    if (CTP_get_apid(&packet) != APID_TLM_AOBC)
     {
       // FIXME: アノマリいれる？ 最後のエラーは以下で保存されるので不要な気もする．
       //        AOBC のアノマリ基準は？

--- a/examples/subobc/src/src_user/component_driver/etc/mobc.c
+++ b/examples/subobc/src/src_user/component_driver/etc/mobc.c
@@ -106,7 +106,7 @@ static CDS_ERR_CODE MOBC_analyze_rec_data_(CDS_StreamConfig* p_stream_config, vo
 
   // MOBC からのコマンドは以下のパターン
   //  APID:
-  //      APID_AOBC_CMD
+  //      APID_CMD_TO_AOBC
   //  CCP_EXEC_TYPE:
   //      CCP_EXEC_TYPE_GS    <- GS から MOBC のキューに入らず直接転送されたもの
   //      CCP_EXEC_TYPE_TL0   <- GS から MOBC のキューに入らず直接転送されたもの

--- a/examples/subobc/src/src_user/settings/tlm_cmd/ccsds/apid_define.c
+++ b/examples/subobc/src/src_user/settings/tlm_cmd/ccsds/apid_define.c
@@ -11,14 +11,14 @@ APID APID_get_apid_from_uint16(uint16_t apid)
 {
   switch ((APID)apid)
   {
-  case APID_MOBC_CMD:   // FALLTHROUGH
-  case APID_AOBC_CMD:   // FALLTHROUGH
-  case APID_TOBC_CMD:   // FALLTHROUGH
-  case APID_TCAL_TLM:   // FALLTHROUGH
-  case APID_MOBC_TLM:   // FALLTHROUGH
-  case APID_AOBC_TLM:   // FALLTHROUGH
-  case APID_TOBC_TLM:   // FALLTHROUGH
-  case APID_DUMP_TLM:   // FALLTHROUGH
+  case APID_CMD_TO_MOBC:  // FALLTHROUGH
+  case APID_CMD_TO_AOBC:  // FALLTHROUGH
+  case APID_CMD_TO_TOBC:  // FALLTHROUGH
+  case APID_TLM_TCAL:     // FALLTHROUGH
+  case APID_TLM_MOBC:     // FALLTHROUGH
+  case APID_TLM_AOBC:     // FALLTHROUGH
+  case APID_TLM_TOBC:     // FALLTHROUGH
+  case APID_TLM_DUMP:     // FALLTHROUGH
   case APID_FILL_PKT:
     return (APID)apid;
 

--- a/examples/subobc/src/src_user/settings/tlm_cmd/ccsds/apid_define.h
+++ b/examples/subobc/src/src_user/settings/tlm_cmd/ccsds/apid_define.h
@@ -12,18 +12,7 @@
  * @enum   APID
  * @brief  Application Process ID
  * @note   11bit
- * @note   命名規則:
- *           Tlm: APID_TLM_{送信元}_TO_{受信先}_VIA_{経由地}
- *           Cmd: APID_CMD_{送信元}_TO_{受信先}_VIA_{経由地}
- *           ただし，Tlm の TO_SGS，Cmd の SGS は省略できる
- *           例:
- *             APID_CMD_TO_MOBC (SGS を省略)
- *             APID_TLM_AOBC (TO_SGS を省略．パスが単一しかありえないので， VIA_MOBCも省略)
- *             APID_TLM_CAMERA_TO_XGS_VIA_MIF (全部記載)
- *           注意:
- *             同一コンポからアプリケーション等を区別して APID を発行したい場合 (eg; HK テレメ，ミッションデータ，Sバンドデータ，X バンドデータ，など) は {送信元} にそれを識別する命名ができる
- *             APID_TLM_AOBC, APID_TLM_AOBC_STT_IMG, など
- *           詳細: https://github.com/arkedge/c2a-core/issues/186#issuecomment-1798685321
+ * @note   命名規則は tlm_cmd/common_tlm_cmd_packet.h を参照
  */
 typedef enum
 {

--- a/examples/subobc/src/src_user/settings/tlm_cmd/ccsds/apid_define.h
+++ b/examples/subobc/src/src_user/settings/tlm_cmd/ccsds/apid_define.h
@@ -12,18 +12,30 @@
  * @enum   APID
  * @brief  Application Process ID
  * @note   11bit
+ * @note   命名規則:
+ *           Tlm: APID_TLM_{送信元}_TO_{受信先}_VIA_{経由地}
+ *           Cmd: APID_CMD_{送信元}_TO_{受信先}_VIA_{経由地}
+ *           ただし，Tlm の TO_SGS，Cmd の SGS は省略できる
+ *           例:
+ *             APID_CMD_TO_MOBC (SGS を省略)
+ *             APID_TLM_AOBC (TO_SGS を省略．パスが単一しかありえないので， VIA_MOBCも省略)
+ *             APID_TLM_CAMERA_TO_XGS_VIA_MIF (全部記載)
+ *           注意:
+ *             同一コンポからアプリケーション等を区別して APID を発行したい場合 (eg; HK テレメ，ミッションデータ，Sバンドデータ，X バンドデータ，など) は {送信元} にそれを識別する命名ができる
+ *             APID_TLM_AOBC, APID_TLM_AOBC_STT_IMG, など
+ *           詳細: https://github.com/arkedge/c2a-core/issues/186#issuecomment-1798685321
  */
 typedef enum
 {
-  APID_MOBC_CMD = 0x210,    //!< 01000010000b: APID for MOBC 宛の CMD
-  APID_AOBC_CMD = 0x211,    //!< 01000010001b: APID for AOBC 宛の CMD
-  APID_TOBC_CMD = 0x212,    //!< 01000010010b: APID for TOBC 宛の CMD
-  APID_TCAL_TLM = 0x410,    //!< 10000010000b: APID for TIME CARIBLATION TLM (FIXME: 現在まともに使ってない)
-  APID_MOBC_TLM = 0x510,    //!< 10100010000b: APID for MOBC で生成される TLM
-  APID_AOBC_TLM = 0x511,    //!< 10100010001b: APID for AOBC で生成される TLM
-  APID_TOBC_TLM = 0x512,    //!< 10100010002b: APID for TOBC で生成される TLM
-  APID_DUMP_TLM = 0x710,    //!< 11100010000b: APID for DUMP TLM (FIXME: 現在まともに使ってない)
-  APID_FILL_PKT = 0x7ff,    //!< 11111111111b: APID for FILL PACKET
+  APID_CMD_TO_MOBC = 0x210,   //!< 01000010000b: APID for MOBC 宛の CMD
+  APID_CMD_TO_AOBC = 0x211,   //!< 01000010001b: APID for AOBC 宛の CMD
+  APID_CMD_TO_TOBC = 0x212,   //!< 01000010010b: APID for TOBC 宛の CMD
+  APID_TLM_TCAL = 0x410,      //!< 10000010000b: APID for TIME CARIBLATION TLM (FIXME: 現在まともに使ってない)
+  APID_TLM_MOBC = 0x510,      //!< 10100010000b: APID for MOBC で生成される TLM
+  APID_TLM_AOBC = 0x511,      //!< 10100010001b: APID for AOBC で生成される TLM
+  APID_TLM_TOBC = 0x512,      //!< 10100010002b: APID for TOBC で生成される TLM
+  APID_TLM_DUMP = 0x710,      //!< 11100010000b: APID for DUMP TLM (FIXME: 現在まともに使ってない)
+  APID_FILL_PKT = 0x7ff,      //!< 11111111111b: APID for FILL PACKET
   APID_UNKNOWN
 } APID;
 

--- a/examples/subobc/src/src_user/settings/tlm_cmd/common_cmd_packet_define.h
+++ b/examples/subobc/src/src_user/settings/tlm_cmd/common_cmd_packet_define.h
@@ -15,7 +15,7 @@ typedef CmdSpacePacket CommonCmdPacket;
 
 // 自分宛て CMD を示す AIPD を定義
 // FIXME: Space Packet が整備されたら直す
-#define CCP_APID_CMD_TO_ME (APID_AOBC_CMD)
+#define CCP_APID_CMD_TO_ME (APID_CMD_TO_AOBC)
 
 /**
  * @enum   CCP_DEST_TYPE

--- a/examples/subobc/src/src_user/settings/tlm_cmd/common_cmd_packet_define.h
+++ b/examples/subobc/src/src_user/settings/tlm_cmd/common_cmd_packet_define.h
@@ -15,7 +15,7 @@ typedef CmdSpacePacket CommonCmdPacket;
 
 // 自分宛て CMD を示す AIPD を定義
 // FIXME: Space Packet が整備されたら直す
-#define CCP_APID_TO_ME (APID_AOBC_CMD)
+#define CCP_APID_CMD_TO_ME (APID_AOBC_CMD)
 
 /**
  * @enum   CCP_DEST_TYPE

--- a/examples/subobc/src/src_user/settings/tlm_cmd/common_tlm_packet_define.h
+++ b/examples/subobc/src/src_user/settings/tlm_cmd/common_tlm_packet_define.h
@@ -15,6 +15,6 @@ typedef TlmSpacePacket CommonTlmPacket;
 
 // 自分で生成される TLM を示す AIPD を定義
 // FIXME: Space Packet が整備されたら直す
-#define CTP_APID_FROM_ME (APID_AOBC_TLM)
+#define CTP_APID_TLM_FROM_ME (APID_AOBC_TLM)
 
 #endif

--- a/examples/subobc/src/src_user/settings/tlm_cmd/common_tlm_packet_define.h
+++ b/examples/subobc/src/src_user/settings/tlm_cmd/common_tlm_packet_define.h
@@ -15,6 +15,6 @@ typedef TlmSpacePacket CommonTlmPacket;
 
 // 自分で生成される TLM を示す AIPD を定義
 // FIXME: Space Packet が整備されたら直す
-#define CTP_APID_TLM_FROM_ME (APID_AOBC_TLM)
+#define CTP_APID_TLM_FROM_ME (APID_TLM_AOBC)
 
 #endif

--- a/examples/subobc/src/src_user/test/test_comm_between_c2a.py
+++ b/examples/subobc/src/src_user/test/test_comm_between_c2a.py
@@ -22,7 +22,7 @@ ope = wings_utils.get_wings_operation()
 
 SUB_OBC = "AOBC"
 Tlm_CODE_SUB_OBC_HK = c2a_enum.Tlm_CODE_AOBC_HK
-TLM_APID_SUB_OBC = c2a_enum.APID_AOBC_TLM
+TLM_APID_SUB_OBC = c2a_enum.APID_TLM_AOBC
 USE_BCT_ID = 100
 
 # NOP だと id が 0x00 なのでちがうのを

--- a/tlm_cmd/ccsds/space_packet_protocol/cmd_space_packet.c
+++ b/tlm_cmd/ccsds/space_packet_protocol/cmd_space_packet.c
@@ -290,7 +290,7 @@ void CSP_set_common_hdr(CmdSpacePacket* csp)
   // ここでは Secondary Header は必須
   CSP_set_2nd_hdr_flag(csp, SP_2ND_HDR_FLAG_PRESENT);
   // APID
-  CSP_set_apid(csp, CCP_APID_TO_ME);
+  CSP_set_apid(csp, CCP_APID_CMD_TO_ME);
   // ここでは Sequence Flag は Standalone Packet に固定
   CSP_set_seq_flag(csp, SP_SEQ_FLAG_SINGLE);
   // ここでは Sequence Count は 0 固定

--- a/tlm_cmd/common_cmd_packet.h
+++ b/tlm_cmd/common_cmd_packet.h
@@ -25,7 +25,7 @@ typedef enum
   CCP_DEST_TYPE_TO_APID   = 0xf
 } CCP_DEST_TYPE;
 */
-// さらに， CCP_APID_TO_ME, CCP_MAX_LEN, CommonCmdPacket として使うパケット型を指定する
+// さらに， CCP_APID_CMD_TO_ME, CCP_MAX_LEN, CommonCmdPacket として使うパケット型を指定する
 #include <src_user/settings/tlm_cmd/common_cmd_packet_define.h>
 
 // ここで APID を定義する

--- a/tlm_cmd/common_tlm_cmd_packet.h
+++ b/tlm_cmd/common_tlm_cmd_packet.h
@@ -14,11 +14,20 @@
 #include "./common_tlm_packet.h"
 #include "./common_cmd_packet.h"
 
-// ここで APID を定義する
-// APID_UNKNOWN, APID_FILL_PKT は必須
+// ここで APID を定義する．APID_UNKNOWN, APID_FILL_PKT は必須とする．
+//   命名規則:
+//     Tlm: APID_TLM_{送信元}_TO_{受信先}_VIA_{経由地}
+//     Cmd: APID_CMD_{送信元}_TO_{受信先}_VIA_{経由地}
+//     ただし，Tlm の TO_SGS，Cmd の SGS は省略できる
+//     例:
+//       APID_CMD_TO_MOBC (SGS を省略)
+//       APID_TLM_AOBC (TO_SGS を省略．パスが単一しかありえないので， VIA_MOBCも省略)
+//       APID_TLM_CAMERA_TO_XGS_VIA_MIF (全部記載)
+//     注意:
+//       同一コンポからアプリケーション等を区別して APID を発行したい場合 (eg; HK テレメ，ミッションデータ，Sバンドデータ，X バンドデータ，など) は {送信元} にそれを識別する命名ができる
+//       APID_TLM_AOBC, APID_TLM_AOBC_STT_IMG, など
+//     詳細: https://github.com/arkedge/c2a-core/issues/186#issuecomment-1798685321
 /* 例
-// FIXME: CCSDS JAXA 標準になおす
-// FIXME: APID は Space Packet なので， CTCP にあるのは不適切？ 抽象化してもいいかも
 typedef enum
 {
   APID_CMD_TO_MOBC = 0x210,   //!< 01000010000b: APID for MOBC 宛の CMD
@@ -33,6 +42,8 @@ typedef enum
   APID_UNKNOWN
 } APID;
 */
+// FIXME: CCSDS JAXA 標準になおす
+// FIXME: APID は Space Packet なので， CTCP にあるのは不適切？ 抽象化してもいいかも
 #include <src_user/settings/tlm_cmd/ccsds/apid_define.h>
 
 

--- a/tlm_cmd/common_tlm_cmd_packet.h
+++ b/tlm_cmd/common_tlm_cmd_packet.h
@@ -21,15 +21,15 @@
 // FIXME: APID は Space Packet なので， CTCP にあるのは不適切？ 抽象化してもいいかも
 typedef enum
 {
-  APID_MOBC_CMD = 0x210,    //!< 01000010000b: APID for MOBC 宛の CMD
-  APID_AOBC_CMD = 0x211,    //!< 01000010001b: APID for AOBC 宛の CMD
-  APID_TOBC_CMD = 0x212,    //!< 01000010010b: APID for TOBC 宛の CMD
-  APID_TCAL_TLM = 0x410,    //!< 10000010000b: APID for TIME CARIBLATION TLM (FIXME: 現在まともに使ってない)
-  APID_MOBC_TLM = 0x510,    //!< 10100010000b: APID for MOBC で生成される TLM
-  APID_AOBC_TLM = 0x511,    //!< 10100010001b: APID for AOBC で生成される TLM
-  APID_TOBC_TLM = 0x512,    //!< 10100010002b: APID for TOBC で生成される TLM
-  APID_DUMP_TLM = 0x710,    //!< 11100010000b: APID for DUMP TLM (FIXME: 現在まともに使ってない)
-  APID_FILL_PKT = 0x7ff,    //!< 11111111111b: APID for FILL PACKET
+  APID_CMD_TO_MOBC = 0x210,   //!< 01000010000b: APID for MOBC 宛の CMD
+  APID_CMD_TO_AOBC = 0x211,   //!< 01000010001b: APID for AOBC 宛の CMD
+  APID_CMD_TO_TOBC = 0x212,   //!< 01000010010b: APID for TOBC 宛の CMD
+  APID_TLM_TCAL = 0x410,      //!< 10000010000b: APID for TIME CARIBLATION TLM (FIXME: 現在まともに使ってない)
+  APID_TLM_MOBC = 0x510,      //!< 10100010000b: APID for MOBC で生成される TLM
+  APID_TLM_AOBC = 0x511,      //!< 10100010001b: APID for AOBC で生成される TLM
+  APID_TLM_TOBC = 0x512,      //!< 10100010002b: APID for TOBC で生成される TLM
+  APID_TLM_DUMP = 0x710,      //!< 11100010000b: APID for DUMP TLM (FIXME: 現在まともに使ってない)
+  APID_FILL_PKT = 0x7ff,      //!< 11111111111b: APID for FILL PACKET
   APID_UNKNOWN
 } APID;
 */

--- a/tlm_cmd/common_tlm_packet.h
+++ b/tlm_cmd/common_tlm_packet.h
@@ -9,7 +9,7 @@
 #include "../system/time_manager/obc_time.h"
 #include <src_user/tlm_cmd/telemetry_definitions.h>
 
-// ここで， CTP_APID_FROM_ME, CTP_MAX_LEN, CommonTlmPacket として使うパケット型を指定する
+// ここで， CTP_APID_TLM_FROM_ME, CTP_MAX_LEN, CommonTlmPacket として使うパケット型を指定する
 #include <src_user/settings/tlm_cmd/common_tlm_packet_define.h>
 
 // ここで APID を定義する

--- a/tlm_cmd/packet_handler.c
+++ b/tlm_cmd/packet_handler.c
@@ -236,7 +236,7 @@ CCP_CmdRet PH_dispatch_command(const CommonCmdPacket* packet)
   }
 
   // FIXME: CTCP, SpacePacket 整理で直す
-  if (CCP_get_apid(packet) == CCP_APID_TO_ME)
+  if (CCP_get_apid(packet) == CCP_APID_CMD_TO_ME)
   {
     // 自分宛てのコマンドの場合は対応処理を呼び出し。
     return CA_execute_cmd(packet);

--- a/tlm_cmd/telemetry_generator.c
+++ b/tlm_cmd/telemetry_generator.c
@@ -102,7 +102,7 @@ CCP_CmdRet Cmd_GENERATE_TLM(const CommonCmdPacket* packet)
   {
     // Primary Header
     // FIXME: Space Packet 依存を直す
-    TSP_setup_primary_hdr(&TG_ctp_, CTP_APID_FROM_ME, TG_get_next_seq_count_(), len);
+    TSP_setup_primary_hdr(&TG_ctp_, CTP_APID_TLM_FROM_ME, TG_get_next_seq_count_(), len);
 
     // Secondary Header
     TSP_set_board_time(&TG_ctp_, (uint32_t)(TMGR_get_master_total_cycle()));
@@ -246,7 +246,7 @@ static CCP_CmdRet TG_generate_tlm_(TLM_CODE tlm_id,
   // 自身の OBC のテレメ生成を前提としているので， Cmd_GENERATE_TLM のように sub OBC 判定はいれない
 
   // Primary Header
-  TSP_setup_primary_hdr(&TG_ctp_, CTP_APID_FROM_ME, TG_get_next_seq_count_(), packet_len);
+  TSP_setup_primary_hdr(&TG_ctp_, CTP_APID_TLM_FROM_ME, TG_get_next_seq_count_(), packet_len);
 
   // Secondary Header
   TSP_set_2nd_hdr_ver(&TG_ctp_, TSP_2ND_HDR_VER_1);


### PR DESCRIPTION
## 概要
APID の命名規則を更新する．
命名規則は https://github.com/arkedge/c2a-core/blob/develop/tlm_cmd/common_tlm_cmd_packet.h に記載した

## Issue
- https://github.com/arkedge/c2a-core/issues/186


## 検証結果
CI が通ればOK

## 補足
- [x] https://github.com/arkedge/c2a-core/pull/219 のマージ後に，changelogを更新する

<!--
## 注意
- 関連する Projects が存在する場合，それの紐付けを行うこと
- Assignees を設定すること
- 可能ならば Reviewers を設定すること
- 可能ならば `priority` ラベルを付けること
-->
