### PR TITLE
Run Rust CI on all workspace crates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,10 +37,10 @@ jobs:
         uses: sksat/action-clippy@v0.3.0
         with:
           reporter: ${{ github.event_name == 'pull_request' && 'github-pr-review' || 'github-check' }}
-          clippy_flags: --all-features
+          clippy_flags: --workspace --all-features
 
       - name: format
         run: cargo fmt --all -- --check
 
       - name: unit test
-        run: cargo test
+        run: cargo test --workspace


### PR DESCRIPTION
## 概要
Rust CI を c2a-core crate だけでなく cargo workspace のすべてのメンバについて走らせるようにする

## Issue
              これは Rust CI がコケてほしい

_Originally posted by @sksat in https://github.com/arkedge/c2a-core/issues/221#issuecomment-1840005774_
            

## 影響範囲
Rust CI