### PR TITLE
[stable-4.0] backport PL_BC_LIST_CLEARED を level high で EL 登録する

### DIFF
--- a/applications/timeline_command_dispatcher.c
+++ b/applications/timeline_command_dispatcher.c
@@ -254,6 +254,7 @@ CCP_CmdRet Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
   TLCD_ID id = (TLCD_ID)CCP_get_param_from_packet(packet, 0, uint8_t);
   bct_id_t block_no = CCP_get_param_from_packet(packet, 1, bct_id_t);
   PL_ACK   ack;
+  const uint32_t note = ((0x000000ff & id) << 24) | (0x00ffffff & block_no);
 
   if (CCP_get_param_len(packet) != (1 + SIZE_OF_BCT_ID_T))
   {
@@ -281,7 +282,7 @@ CCP_CmdRet Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
     EL_record_event((EL_GROUP)EL_CORE_GROUP_TLCD_DEPLOY_BLOCK,
                     (uint32_t)PL_BC_LIST_CLEARED,
                     EL_ERROR_LEVEL_HIGH,
-                    (uint32_t)( ((0x000000ff & id) << 24) | (0x00ffffff & block_no) ));
+                    note);
     return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_CONTEXT, (uint32_t)ack);
   }
   else if (ack != PL_SUCCESS)
@@ -289,7 +290,7 @@ CCP_CmdRet Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
     EL_record_event((EL_GROUP)EL_CORE_GROUP_TLCD_DEPLOY_BLOCK,
                     (uint32_t)ack,
                     EL_ERROR_LEVEL_LOW,
-                    (uint32_t)( ((0x000000ff & id) << 24) | (0x00ffffff & block_no) ));
+                    note);
     if (ack == PL_BC_TIME_ADJUSTED)
     {
       return CCP_make_cmd_ret(CCP_EXEC_SUCCESS, (uint32_t)ack);

--- a/applications/timeline_command_dispatcher.c
+++ b/applications/timeline_command_dispatcher.c
@@ -276,7 +276,15 @@ CCP_CmdRet Cmd_TLCD_DEPLOY_BLOCK(const CommonCmdPacket* packet)
 
   ack = PL_deploy_block_cmd(&(PH_tl_cmd_list[id]), block_no, TMGR_get_master_total_cycle());
 
-  if (ack != PL_SUCCESS)
+  if (ack == PL_BC_LIST_CLEARED)
+  {
+    EL_record_event((EL_GROUP)EL_CORE_GROUP_TLCD_DEPLOY_BLOCK,
+                    (uint32_t)PL_BC_LIST_CLEARED,
+                    EL_ERROR_LEVEL_HIGH,
+                    (uint32_t)( ((0x000000ff & id) << 24) | (0x00ffffff & block_no) ));
+    return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_CONTEXT, (uint32_t)ack);
+  }
+  else if (ack != PL_SUCCESS)
   {
     EL_record_event((EL_GROUP)EL_CORE_GROUP_TLCD_DEPLOY_BLOCK,
                     (uint32_t)ack,


### PR DESCRIPTION
## 概要
[ut-issl/c2a-core](https://github.com/ut-issl/c2a-core) [v3.10.1](https://github.com/ut-issl/c2a-core/releases/tag/v3.10.1) のバックポート

## Issue / PR
- #213 
- #103 
- https://github.com/ut-issl/c2a-core/pull/640
- #188 

## 詳細
以下を cherry-pick
- [x] 9510ae855dd6dc9c5942fdbb88fe0abdab52c961 from https://github.com/ut-issl/c2a-core/pull/640
- [x] 66f6a9e4a5d9907467147a151bbec7185ecd3254 from #188 

## 検証結果
CI が通れば OK