### PR TITLE
[code-generator] 自動生成コードの @note に，生成元DBのコミットハッシュと生成パラメータを出力する

### DIFF
--- a/.github/workflows/check_code_generation.yml
+++ b/.github/workflows/check_code_generation.yml
@@ -25,6 +25,8 @@ jobs:
         working-directory: ./code-generator
         run: |
           cp "./settings_${{ matrix.user }}.json" ./settings.json
+          # sub obc の tlm cmd db は見ない
+          sed -i 's/  "is_main_obc" : 1,/  "is_main_obc" : 0,/g' ./settings.json
           python GenerateC2ACode.py
 
       - name: check diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 注意: これは既存の C2A core update の「リリースの間の Pull Request を眺めてなんとなく察する」という曖昧な操作を緩和していくための試みであり，C2A user に対するお知らせを行う場として使っていくことを意図しています．初めから c2a-core の全変更を取り扱うと不必要に煩雑になるだけになってしまうため，完全な変更内容の一覧についてはこれまで通り [GitHub Releases](https://github.com/arkedge/c2a-core/releases) などから参照してください．
 
+## v4.2.0 (Unreleased-12-11)
+
+### Enhancements
+- [#240](https://github.com/arkedge/c2a-core/pull/240): code-generator の出力コードに，設定情報を残すようにする
+
+
 ## v4.1.0 (2023-12-11)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 ### Enhancements
 - [#240](https://github.com/arkedge/c2a-core/pull/240): code-generator の出力コードに，設定情報を残すようにする
 
+### Migration Guide
+- [#240](https://github.com/arkedge/c2a-core/pull/240): user 側でのコードレベルでの対応は不要
+  - 新しい code-generator で生成したコードは，既存のものと diff が発生するため，改めてコード生成し直すとよい．
+
 
 ## v4.1.0 (2023-12-11)
 

--- a/code-generator/README.md
+++ b/code-generator/README.md
@@ -16,13 +16,15 @@ $ python GenerateC2ACode.py
 ## 設定
 実行時のパスと同じディレクトリに `settings.json` を置いて設定する．
 
-`is_main_obc` は，MOBC（地上局と通信するOBC．2nd OBCのtlm/cmdを取りまとめる）かそれ以外のOBC（2nd OBC．MOBCと通信するOBC）かを制御する．  
-`1` とした場合，MOBCを意図したコードが生成され，加えて以下が生成される．
-- 2nd_obc_command_definitions.h
-- 2nd_obc_telemetry_definitions.h
-- 2nd_obc_telemetry_buffer.c
-- 2nd_obc_telemetry_buffer.h
-- 2nd_obc_telemetry_data_definitions.h
+`is_main_obc` は，MOBC（地上局と通信するOBC．sub OBCのtlm/cmdを取りまとめる）かそれ以外のOBC（sub OBC．MOBCと通信するOBC）かを制御する．  
+`1` とした場合，MOBC用のコードに加えて以下が生成される．
+- sub_obc_command_definitions.h
+- sub_obc_telemetry_definitions.h
+- sub_obc_telemetry_buffer.c
+- sub_obc_telemetry_buffer.h
+- sub_obc_telemetry_data_definitions.h
+
+なお，MOBC の場合でも， `0` にすることで， sub OBC のコードを生成せず， MOBC のコードのみを生成することができる
 
 設定の記述例（JSON としては invalid だがコメント付き）
 ```
@@ -42,7 +44,8 @@ $ python GenerateC2ACode.py
   # 出力ファイルのエンコーディング
   "output_file_encoding" : "utf-8",
   # MOBCか？（他のOBCのtlm/cmdを取りまとめるか？） 0/1
-  # 2nd OBCのコードを生成するときなどは 0 にする
+  # sub OBCのコードを生成するときなどは 0 にする
+  # MOBC の場合でも， 0 にすることで， sub OBC のコードを生成せず， MOBC のコードのみを生成することができる
   # 0 の場合，以後のパラメタは無効
   "is_main_obc" : 1,
   "other_obc_data" : [
@@ -97,4 +100,4 @@ $ pip install -r requirements.txt
 
 ## その他
 - [settings_mobc.json](./settings_mobc.json), [settings_subobc.json](./settings_subobc.json) は c2a-core example user での設定
-- MOBCと2nd OBCのC2A間通信の例は （TBA）．
+- MOBCとsub OBCのC2A間通信の例は （TBA）．

--- a/code-generator/my_mod/cmd_def.py
+++ b/code-generator/my_mod/cmd_def.py
@@ -188,8 +188,8 @@ def OutputCmdDefC_(file_path, body, settings):
 #pragma section REPRO
 /**
  * @file
- * @brief  コマンド定義
- * @note   このコードは自動生成されています！
+ * @brief コマンド定義
+ * @note  このコードは自動生成されています！
  */
 #include <src_core/tlm_cmd/command_analyze.h>
 #include "command_definitions.h"
@@ -220,8 +220,8 @@ def OutputCmdDefH_(file_path, body, settings):
     output += """
 /**
  * @file
- * @brief  コマンド定義
- * @note   このコードは自動生成されています！
+ * @brief コマンド定義
+ * @note  このコードは自動生成されています！
  */
 #ifndef COMMAND_DEFINITIONS_H_
 #define COMMAND_DEFINITIONS_H_
@@ -253,8 +253,8 @@ def OutputBctDef_(file_path, body, settings):
     output += """
 /**
  * @file
- * @brief  ブロックコマンド定義
- * @note   このコードは自動生成されています！
+ * @brief ブロックコマンド定義
+ * @note  このコードは自動生成されています！
  */
 #ifndef BLOCK_COMMAND_DEFINITIONS_H_
 #define BLOCK_COMMAND_DEFINITIONS_H_
@@ -293,8 +293,8 @@ def OutputOtherObcCmdDefH_(file_path, name, body, settings):
     output += """
 /**
  * @file
- * @brief  コマンド定義
- * @note   このコードは自動生成されています！
+ * @brief コマンド定義
+ * @note  このコードは自動生成されています！
  */
 #ifndef {_obc_name_upper}_COMMAND_DEFINITIONS_H_
 #define {_obc_name_upper}_COMMAND_DEFINITIONS_H_

--- a/code-generator/my_mod/cmd_def.py
+++ b/code-generator/my_mod/cmd_def.py
@@ -4,6 +4,7 @@ cmd def
 """
 
 import sys
+import my_mod.util
 
 # import pprint
 
@@ -170,7 +171,7 @@ def GenerateOtherObcCmdDef(settings, other_obc_dbs):
             + name_lower
             + "_command_definitions.h"
         )
-        OutputOtherObcCmdDefH_(output_file_path, obc_name, body_h, settings)
+        OutputOtherObcCmdDefH_(output_file_path, obc_name, body_h, settings, i)
 
 
 def GetCmdNameAndCmdCode_(name, is_cmd_prefixed_in_db):
@@ -189,7 +190,13 @@ def OutputCmdDefC_(file_path, body, settings):
 /**
  * @file
  * @brief コマンド定義
- * @note  このコードは自動生成されています！
+"""[
+        1:
+    ]  # 最初の改行を除く
+
+    output += my_mod.util.GenerateSettingNote(settings)
+
+    output += """
  */
 #include <src_core/tlm_cmd/command_analyze.h>
 #include "command_definitions.h"
@@ -221,7 +228,13 @@ def OutputCmdDefH_(file_path, body, settings):
 /**
  * @file
  * @brief コマンド定義
- * @note  このコードは自動生成されています！
+"""[
+        1:
+    ]  # 最初の改行を除く
+
+    output += my_mod.util.GenerateSettingNote(settings)
+
+    output += """
  */
 #ifndef COMMAND_DEFINITIONS_H_
 #define COMMAND_DEFINITIONS_H_
@@ -254,7 +267,13 @@ def OutputBctDef_(file_path, body, settings):
 /**
  * @file
  * @brief ブロックコマンド定義
- * @note  このコードは自動生成されています！
+"""[
+        1:
+    ]  # 最初の改行を除く
+
+    output += my_mod.util.GenerateSettingNote(settings)
+
+    output += """
  */
 #ifndef BLOCK_COMMAND_DEFINITIONS_H_
 #define BLOCK_COMMAND_DEFINITIONS_H_
@@ -284,7 +303,7 @@ void BC_load_defaults(void);
         fh.write(output)
 
 
-def OutputOtherObcCmdDefH_(file_path, name, body, settings):
+def OutputOtherObcCmdDefH_(file_path, name, body, settings, obc_idx):
     name_upper = name.upper()
     name_lower = name.lower()
     name_capit = name.capitalize()
@@ -294,7 +313,13 @@ def OutputOtherObcCmdDefH_(file_path, name, body, settings):
 /**
  * @file
  * @brief コマンド定義
- * @note  このコードは自動生成されています！
+"""[
+        1:
+    ]  # 最初の改行を除く
+
+    output += my_mod.util.GenerateSubObcSettingNote(settings, obc_idx)
+
+    output += """
  */
 #ifndef {_obc_name_upper}_COMMAND_DEFINITIONS_H_
 #define {_obc_name_upper}_COMMAND_DEFINITIONS_H_

--- a/code-generator/my_mod/tlm_buffer.py
+++ b/code-generator/my_mod/tlm_buffer.py
@@ -365,8 +365,8 @@ def OutputTlmBufferC_(file_path, name, body, settings):
 #pragma section REPRO
 /**
  * @file
- * @brief  テレメトリバッファー（テレメ中継）
- * @note   このコードは自動生成されています！
+ * @brief テレメトリバッファー（テレメ中継）
+ * @note  このコードは自動生成されています！
  */
 #include <src_core/component_driver/cdrv_common_tlm_cmd_packet.h>
 #include "./{_obc_name_lower}_telemetry_definitions.h"
@@ -403,8 +403,8 @@ def OutputTlmBufferH_(file_path, name, body, settings):
     output += """
 /**
  * @file
- * @brief  テレメトリバッファー（テレメ中継）
- * @note   このコードは自動生成されています！
+ * @brief テレメトリバッファー（テレメ中継）
+ * @note  このコードは自動生成されています！
  */
 #ifndef {_obc_name_upper}_TELEMETRY_BUFFER_H_
 #define {_obc_name_upper}_TELEMETRY_BUFFER_H_
@@ -444,8 +444,8 @@ def OutputTlmDataDefH_(file_path, name, body, settings):
     output += """
 /**
  * @file
- * @brief  バッファリングされているテレメをパースしてMOBC内でかんたんに利用できるようにするためのテレメデータ構造体定義
- * @note   このコードは自動生成されています！
+ * @brief バッファリングされているテレメをパースしてMOBC内でかんたんに利用できるようにするためのテレメデータ構造体定義
+ * @note  このコードは自動生成されています！
  */
 #ifndef {_obc_name_upper}_TELEMETRY_DATA_DEFINITIONS_H_
 #define {_obc_name_upper}_TELEMETRY_DATA_DEFINITIONS_H_

--- a/code-generator/my_mod/tlm_buffer.py
+++ b/code-generator/my_mod/tlm_buffer.py
@@ -343,17 +343,25 @@ def GenerateTlmBuffer(settings, other_obc_dbs):
             + settings["other_obc_data"][i]["driver_path"]
         )
         OutputTlmBufferC_(
-            output_file_path + obc_name.lower() + "_telemetry_buffer.c", obc_name, body_c, settings, i
+            output_file_path + obc_name.lower() + "_telemetry_buffer.c",
+            obc_name,
+            body_c,
+            settings,
+            i,
         )
         OutputTlmBufferH_(
-            output_file_path + obc_name.lower() + "_telemetry_buffer.h", obc_name, body_h, settings, i
+            output_file_path + obc_name.lower() + "_telemetry_buffer.h",
+            obc_name,
+            body_h,
+            settings,
+            i,
         )
         OutputTlmDataDefH_(
             output_file_path + obc_name.lower() + "_telemetry_data_definitions.h",
             obc_name,
             tlmdef_body_h,
             settings,
-            i
+            i,
         )
 
 

--- a/code-generator/my_mod/tlm_buffer.py
+++ b/code-generator/my_mod/tlm_buffer.py
@@ -4,6 +4,7 @@ tlm buffer
 """
 
 import sys
+import my_mod.util
 
 # from collections import OrderedDict
 # import pprint
@@ -342,20 +343,21 @@ def GenerateTlmBuffer(settings, other_obc_dbs):
             + settings["other_obc_data"][i]["driver_path"]
         )
         OutputTlmBufferC_(
-            output_file_path + obc_name.lower() + "_telemetry_buffer.c", obc_name, body_c, settings
+            output_file_path + obc_name.lower() + "_telemetry_buffer.c", obc_name, body_c, settings, i
         )
         OutputTlmBufferH_(
-            output_file_path + obc_name.lower() + "_telemetry_buffer.h", obc_name, body_h, settings
+            output_file_path + obc_name.lower() + "_telemetry_buffer.h", obc_name, body_h, settings, i
         )
         OutputTlmDataDefH_(
             output_file_path + obc_name.lower() + "_telemetry_data_definitions.h",
             obc_name,
             tlmdef_body_h,
             settings,
+            i
         )
 
 
-def OutputTlmBufferC_(file_path, name, body, settings):
+def OutputTlmBufferC_(file_path, name, body, settings, obc_idx):
     name_upper = name.upper()
     name_lower = name.lower()
     name_capit = name.capitalize()
@@ -366,7 +368,13 @@ def OutputTlmBufferC_(file_path, name, body, settings):
 /**
  * @file
  * @brief テレメトリバッファー（テレメ中継）
- * @note  このコードは自動生成されています！
+"""[
+        1:
+    ]  # 最初の改行を除く
+
+    output += my_mod.util.GenerateSubObcSettingNote(settings, obc_idx)
+
+    output += """
  */
 #include <src_core/component_driver/cdrv_common_tlm_cmd_packet.h>
 #include "./{_obc_name_lower}_telemetry_definitions.h"
@@ -394,7 +402,7 @@ def OutputTlmBufferC_(file_path, name, body, settings):
         )
 
 
-def OutputTlmBufferH_(file_path, name, body, settings):
+def OutputTlmBufferH_(file_path, name, body, settings, obc_idx):
     name_upper = name.upper()
     name_lower = name.lower()
     name_capit = name.capitalize()
@@ -404,7 +412,13 @@ def OutputTlmBufferH_(file_path, name, body, settings):
 /**
  * @file
  * @brief テレメトリバッファー（テレメ中継）
- * @note  このコードは自動生成されています！
+"""[
+        1:
+    ]  # 最初の改行を除く
+
+    output += my_mod.util.GenerateSubObcSettingNote(settings, obc_idx)
+
+    output += """
  */
 #ifndef {_obc_name_upper}_TELEMETRY_BUFFER_H_
 #define {_obc_name_upper}_TELEMETRY_BUFFER_H_
@@ -435,7 +449,7 @@ def OutputTlmBufferH_(file_path, name, body, settings):
         )
 
 
-def OutputTlmDataDefH_(file_path, name, body, settings):
+def OutputTlmDataDefH_(file_path, name, body, settings, obc_idx):
     name_upper = name.upper()
     name_lower = name.lower()
     name_capit = name.capitalize()
@@ -445,7 +459,13 @@ def OutputTlmDataDefH_(file_path, name, body, settings):
 /**
  * @file
  * @brief バッファリングされているテレメをパースしてMOBC内でかんたんに利用できるようにするためのテレメデータ構造体定義
- * @note  このコードは自動生成されています！
+"""[
+        1:
+    ]  # 最初の改行を除く
+
+    output += my_mod.util.GenerateSubObcSettingNote(settings, obc_idx)
+
+    output += """
  */
 #ifndef {_obc_name_upper}_TELEMETRY_DATA_DEFINITIONS_H_
 #define {_obc_name_upper}_TELEMETRY_DATA_DEFINITIONS_H_

--- a/code-generator/my_mod/tlm_def.py
+++ b/code-generator/my_mod/tlm_def.py
@@ -152,8 +152,8 @@ def OutputTlmDefC_(file_path, body, settings):
 #pragma section REPRO
 /**
  * @file
- * @brief  テレメトリ定義
- * @note   このコードは自動生成されています！
+ * @brief テレメトリ定義
+ * @note  このコードは自動生成されています！
  */
 #include <src_core/tlm_cmd/telemetry_frame.h>
 #include "telemetry_definitions.h"
@@ -181,8 +181,8 @@ def OutputTlmDefH_(file_path, body, settings):
     output += """
 /**
  * @file
- * @brief  テレメトリ定義
- * @note   このコードは自動生成されています！
+ * @brief テレメトリ定義
+ * @note  このコードは自動生成されています！
  */
 #ifndef TELEMETRY_DEFINITIONS_H_
 #define TELEMETRY_DEFINITIONS_H_
@@ -218,8 +218,8 @@ def OutputOtherObcTlmDefH(file_path, name, body, settings):
     output += """
 /**
  * @file
- * @brief  テレメトリ定義
- * @note   このコードは自動生成されています！
+ * @brief テレメトリ定義
+ * @note  このコードは自動生成されています！
  */
 #ifndef {_obc_name_upper}_TELEMETRY_DEFINITIONS_H_
 #define {_obc_name_upper}_TELEMETRY_DEFINITIONS_H_

--- a/code-generator/my_mod/tlm_def.py
+++ b/code-generator/my_mod/tlm_def.py
@@ -4,6 +4,7 @@ tlm def
 """
 
 import sys
+import my_mod.util
 
 
 def GenerateTlmDef(settings, tlm_db):
@@ -143,7 +144,7 @@ def GenerateOtherObcTlmDef(settings, other_obc_dbs):
             + obc_name.lower()
             + "_telemetry_definitions.h"
         )
-        OutputOtherObcTlmDefH(output_file_path, obc_name, body_h, settings)
+        OutputOtherObcTlmDefH(output_file_path, obc_name, body_h, settings, i)
 
 
 def OutputTlmDefC_(file_path, body, settings):
@@ -153,7 +154,13 @@ def OutputTlmDefC_(file_path, body, settings):
 /**
  * @file
  * @brief テレメトリ定義
- * @note  このコードは自動生成されています！
+"""[
+        1:
+    ]  # 最初の改行を除く
+
+    output += my_mod.util.GenerateSettingNote(settings)
+
+    output += """
  */
 #include <src_core/tlm_cmd/telemetry_frame.h>
 #include "telemetry_definitions.h"
@@ -182,7 +189,13 @@ def OutputTlmDefH_(file_path, body, settings):
 /**
  * @file
  * @brief テレメトリ定義
- * @note  このコードは自動生成されています！
+"""[
+        1:
+    ]  # 最初の改行を除く
+
+    output += my_mod.util.GenerateSettingNote(settings)
+
+    output += """
  */
 #ifndef TELEMETRY_DEFINITIONS_H_
 #define TELEMETRY_DEFINITIONS_H_
@@ -209,7 +222,7 @@ typedef enum
         fh.write(output)
 
 
-def OutputOtherObcTlmDefH(file_path, name, body, settings):
+def OutputOtherObcTlmDefH(file_path, name, body, settings, obc_idx):
     name_upper = name.upper()
     name_lower = name.lower()
     name_capit = name.capitalize()
@@ -219,7 +232,13 @@ def OutputOtherObcTlmDefH(file_path, name, body, settings):
 /**
  * @file
  * @brief テレメトリ定義
- * @note  このコードは自動生成されています！
+"""[
+        1:
+    ]  # 最初の改行を除く
+
+    output += my_mod.util.GenerateSubObcSettingNote(settings, obc_idx)
+
+    output += """
  */
 #ifndef {_obc_name_upper}_TELEMETRY_DEFINITIONS_H_
 #define {_obc_name_upper}_TELEMETRY_DEFINITIONS_H_

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -21,8 +21,8 @@ def GenerateSettingNote(settings):
     note += " *          db_prefix:             "
     note += settings["db_prefix"]
     note += "\n"
-    note += " *          tlm_id_range:          ["
-    note += settings["tlm_id_range"][0] + ", " + settings["tlm_id_range"][1] + "]"
+    note += " *          tlm_id_range:          "
+    note += "[" + settings["tlm_id_range"][0] + ", " + settings["tlm_id_range"][1] + "]"
     note += "\n"
     note += " *          is_cmd_prefixed_in_db: "
     note += str(settings["is_cmd_prefixed_in_db"])
@@ -59,7 +59,7 @@ def GenerateSubObcSettingNote(settings, obc_idx):
     note += sub_obc_settings["db_prefix"]
     note += "\n"
     note += " *          tlm_id_range:            "
-    note += sub_obc_settings["tlm_id_range"][0] + ", " + sub_obc_settings["tlm_id_range"][1] + "]"
+    note += "[" + sub_obc_settings["tlm_id_range"][0] + ", " + sub_obc_settings["tlm_id_range"][1] + "]"
     note += "\n"
     note += " *          is_cmd_prefixed_in_db:   "
     note += str(sub_obc_settings["is_cmd_prefixed_in_db"])

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -104,6 +104,10 @@ def GetRepoName_(path):
         result = subprocess.run(["git", "remote", "-v"], cwd=path, text=True, capture_output=True, check=True)
         url = result.stdout.split('\n')[0].split('\t')[1].split(' ')[0]  # 最初のリモートURLを取得
 
+        # URLの末尾に.gitがなければ追加
+        if not url.endswith(".git"):
+            url += ".git"
+
         # URLからユーザー名とリポジトリ名を抽出（HTTPSとSSHの両方に対応）
         match = re.search(r'(?:github\.com[:/])(.+)/(.+)\.git', url)
         if match:

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -13,12 +13,6 @@ def GenerateSettingNote(settings):
     note += GetCommitHash_(settings["path_to_db"])
     note += "\n"
     note += " * @note  コード生成パラメータ:\n"
-    note += " *          path_to_src:           "
-    note += settings["path_to_src"]
-    note += "\n"
-    note += " *          path_to_db:            "
-    note += settings["path_to_db"]
-    note += "\n"
     note += " *          db_prefix:             "
     note += settings["db_prefix"]
     note += "\n"
@@ -35,6 +29,7 @@ def GenerateSettingNote(settings):
     note += settings["output_file_encoding"]
     note += "\n"
     # is_main_obc については，生成状況によって異なるので出力しない
+    # path_to_src, path_to_db については，実行環境によって異なるので出力しない
 
     return note
 
@@ -63,9 +58,6 @@ def GenerateSubObcSettingNote(settings, obc_idx):
     note += " *          input_file_encoding:     "
     note += sub_obc_settings["input_file_encoding"]
     note += "\n"
-    note += " *          path_to_db:              "
-    note += sub_obc_settings["path_to_db"]
-    note += "\n"
     note += " *          max_tlm_num:             "
     note += str(sub_obc_settings["max_tlm_num"])
     note += "\n"
@@ -81,6 +73,7 @@ def GenerateSubObcSettingNote(settings, obc_idx):
     note += " *          code_when_tlm_not_found: "
     note += sub_obc_settings["code_when_tlm_not_found"]
     note += "\n"
+    # path_to_db については，実行環境によって異なるので出力しない
 
     return note
 

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -1,0 +1,95 @@
+# coding: UTF-8
+"""
+util
+"""
+
+import subprocess
+
+
+def GenerateSettingNote(settings):
+    note = ""
+    note += " * @note  このコードは自動生成されています！\n"
+    note += " * @note  コード生成 db commit hash: "
+    note += GetCommitHash_(settings["path_to_db"])
+    note += "\n"
+    note += " * @note  コード生成パラメータ:\n"
+    note += " *          path_to_src:           "
+    note += settings["path_to_src"]
+    note += "\n"
+    note += " *          path_to_db:            "
+    note += settings["path_to_db"]
+    note += "\n"
+    note += " *          db_prefix:             "
+    note += settings["db_prefix"]
+    note += "\n"
+    note += " *          tlm_id_range:          ["
+    note += settings["tlm_id_range"][0] + ", " + settings["tlm_id_range"][1] + "]"
+    note += "\n"
+    note += " *          is_cmd_prefixed_in_db: "
+    note += str(settings["is_cmd_prefixed_in_db"])
+    note += "\n"
+    note += " *          input_file_encoding:   "
+    note += settings["input_file_encoding"]
+    note += "\n"
+    note += " *          output_file_encoding:  "
+    note += settings["output_file_encoding"]
+    note += "\n"
+    # is_main_obc については，生成状況によって異なるので出力しない
+
+    return note
+
+
+def GenerateSubObcSettingNote(settings, obc_idx):
+    sub_obc_settings = settings["other_obc_data"][obc_idx]
+
+    note = ""
+    note += " * @note  このコードは自動生成されています！\n"
+    note += " * @note  コード生成 db commit hash: "
+    note += GetCommitHash_(sub_obc_settings["path_to_db"])
+    note += "\n"
+    note += " * @note  コード生成パラメータ:\n"
+    note += " *          name:                    "
+    note += sub_obc_settings["name"]
+    note += "\n"
+    note += " *          db_prefix:               "
+    note += sub_obc_settings["db_prefix"]
+    note += "\n"
+    note += " *          tlm_id_range:            "
+    note += sub_obc_settings["tlm_id_range"][0] + ", " + sub_obc_settings["tlm_id_range"][1] + "]"
+    note += "\n"
+    note += " *          is_cmd_prefixed_in_db:   "
+    note += str(sub_obc_settings["is_cmd_prefixed_in_db"])
+    note += "\n"
+    note += " *          input_file_encoding:     "
+    note += sub_obc_settings["input_file_encoding"]
+    note += "\n"
+    note += " *          path_to_db:              "
+    note += sub_obc_settings["path_to_db"]
+    note += "\n"
+    note += " *          max_tlm_num:             "
+    note += str(sub_obc_settings["max_tlm_num"])
+    note += "\n"
+    note += " *          driver_path:             "
+    note += sub_obc_settings["driver_path"]
+    note += "\n"
+    note += " *          driver_type:             "
+    note += sub_obc_settings["driver_type"]
+    note += "\n"
+    note += " *          driver_name:             "
+    note += sub_obc_settings["driver_name"]
+    note += "\n"
+    note += " *          code_when_tlm_not_found: "
+    note += sub_obc_settings["code_when_tlm_not_found"]
+    note += "\n"
+
+    return note
+
+
+def GetCommitHash_(path):
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=path, text=True, capture_output=True, check=True
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        return "0000000000000000000000000000000000000000"

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -15,6 +15,7 @@ def GenerateSettingNote(settings):
     note += GetRepoName_(settings["path_to_db"])
     note += "\n"
     note += " *          db commit hash: "
+    note += "xxxx"
     # note += GetCommitHash_(settings["path_to_db"])
     note += "\n"
     note += " * @note  コード生成パラメータ:\n"
@@ -103,8 +104,8 @@ def GetRepoName_(path):
         result = subprocess.run(["git", "remote", "-v"], cwd=path, text=True, capture_output=True, check=True)
         url = result.stdout.split('\n')[0].split('\t')[1].split(' ')[0]  # 最初のリモートURLを取得
 
-        # URLからユーザー名とリポジトリ名を抽出
-        match = re.search(r'github.com[:/](.+)/(.+)\.git', url)
+        # URLからユーザー名とリポジトリ名を抽出（HTTPSとSSHの両方に対応）
+        match = re.search(r'(?:github\.com[:/])(.+)/(.+)\.git', url)
         if match:
             return f"{match.group(1)}/{match.group(2)}"
         else:

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -137,6 +137,13 @@ def GetDbHash_(path):
 
 
 def CalcMd5_(path):
+    # 改行コード問題がうざいので，全部 CRLF に変換して計算
+    with open(path, 'r', encoding='utf-8') as file:
+        content = file.read()
+    content_crlf = content.replace('\n', '\r\n')
+    return hashlib.md5(content_crlf.encode('utf-8')).hexdigest()
+
+
     hash_md5 = hashlib.md5()
     with open(path, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -138,11 +138,10 @@ def GetDbHash_(path):
 
 def CalcMd5_(path):
     # 改行コード問題がうざいので，全部 CRLF に変換して計算
-    with open(path, 'r', encoding='utf-8') as file:
+    with open(path, "r", encoding="utf-8") as file:
         content = file.read()
-    content_crlf = content.replace('\n', '\r\n')
-    return hashlib.md5(content_crlf.encode('utf-8')).hexdigest()
-
+    content_crlf = content.replace("\n", "\r\n")
+    return hashlib.md5(content_crlf.encode("utf-8")).hexdigest()
 
     hash_md5 = hashlib.md5()
     with open(path, "rb") as f:

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -91,5 +91,5 @@ def GetCommitHash_(path):
             ["git", "rev-parse", "HEAD"], cwd=path, text=True, capture_output=True, check=True
         )
         return result.stdout.strip()
-    except subprocess.CalledProcessError as e:
+    except subprocess.CalledProcessError:
         return "0000000000000000000000000000000000000000"

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -15,7 +15,7 @@ def GenerateSettingNote(settings):
     note += GetRepoName_(settings["path_to_db"])
     note += "\n"
     note += " *          db commit hash: "
-    note += GetCommitHash_(settings["path_to_db"])
+    # note += GetCommitHash_(settings["path_to_db"])
     note += "\n"
     note += " * @note  コード生成パラメータ:\n"
     note += " *          db_prefix:             "

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -130,15 +130,15 @@ def GetDbHash_(path):
     csv_files_info = FindCsvFilesAndCalculateMd5_(path)
 
     # ファイル名でソートし，MD5 を結合したのち，その MD5 を計算
-    sorted_info = sorted(csv_files_info, key=lambda x: x['filepath'])
-    concatenated_md5s = ''.join(info['md5'] for info in sorted_info)
+    sorted_info = sorted(csv_files_info, key=lambda x: x["filepath"])
+    concatenated_md5s = "".join(info["md5"] for info in sorted_info)
     final_md5 = hashlib.md5(concatenated_md5s.encode()).hexdigest()
     return final_md5
 
 
 def CalcMd5_(path):
     hash_md5 = hashlib.md5()
-    with open(path, 'rb') as f:
+    with open(path, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
             hash_md5.update(chunk)
     return hash_md5.hexdigest()
@@ -153,5 +153,3 @@ def FindCsvFilesAndCalculateMd5_(path):
                 md5 = CalcMd5_(file_path)
                 csv_files_info.append({"filepath": file_path, "md5": md5})
     return csv_files_info
-
-

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -4,12 +4,17 @@ util
 """
 
 import subprocess
+import re
 
 
 def GenerateSettingNote(settings):
     note = ""
     note += " * @note  このコードは自動生成されています！\n"
-    note += " * @note  コード生成 db commit hash: "
+    note += " * @note  コード生成 tlm-cmd-db:\n"
+    note += " *          repository:     "
+    note += GetRepoName_(settings["path_to_db"])
+    note += "\n"
+    note += " *          db commit hash: "
     note += GetCommitHash_(settings["path_to_db"])
     note += "\n"
     note += " * @note  コード生成パラメータ:\n"
@@ -39,7 +44,11 @@ def GenerateSubObcSettingNote(settings, obc_idx):
 
     note = ""
     note += " * @note  このコードは自動生成されています！\n"
-    note += " * @note  コード生成 db commit hash: "
+    note += " * @note  コード生成 tlm-cmd-db:\n"
+    note += " *          repository:     "
+    note += GetRepoName_(sub_obc_settings["path_to_db"])
+    note += "\n"
+    note += " *          db commit hash: "
     note += GetCommitHash_(sub_obc_settings["path_to_db"])
     note += "\n"
     note += " * @note  コード生成パラメータ:\n"
@@ -86,3 +95,19 @@ def GetCommitHash_(path):
         return result.stdout.strip()
     except subprocess.CalledProcessError:
         return "0000000000000000000000000000000000000000"
+
+
+def GetRepoName_(path):
+    try:
+        # GitリモートURLを取得
+        result = subprocess.run(["git", "remote", "-v"], cwd=path, text=True, capture_output=True, check=True)
+        url = result.stdout.split('\n')[0].split('\t')[1].split(' ')[0]  # 最初のリモートURLを取得
+
+        # URLからユーザー名とリポジトリ名を抽出
+        match = re.search(r'github.com[:/](.+)/(.+)\.git', url)
+        if match:
+            return f"{match.group(1)}/{match.group(2)}"
+        else:
+            return "User/Repository name not found"
+    except subprocess.CalledProcessError:
+        return "User/Repository name not found"

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: f7b24980106fed976f894ffd96608dfa24ad271d
+ *          db commit hash: 11b08aacb01a9a39c6807928b35628e2c946369d
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
@@ -4,11 +4,11 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
+ *          db commit hash: f7b24980106fed976f894ffd96608dfa24ad271d
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC
- *          tlm_id_range:            0x90, 0xc0]
+ *          tlm_id_range:            [0x90, 0xc0]
  *          is_cmd_prefixed_in_db:   0
  *          input_file_encoding:     utf-8
  *          max_tlm_num:             256

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 91057002c3912105ba56ed1e91077ef6a4daf460
+ *          db commit hash: b652ed36ebcf0bf8e900adf444be970c6264bc04
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
@@ -2,14 +2,15 @@
  * @file
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成 tlm-cmd-db:
+ *          repository:     arkedge/c2a-core
+ *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC
  *          tlm_id_range:            0x90, 0xc0]
  *          is_cmd_prefixed_in_db:   0
  *          input_file_encoding:     utf-8
- *          path_to_db:              ../examples/subobc/tlm-cmd-db/
  *          max_tlm_num:             256
  *          driver_path:             aocs/
  *          driver_type:             AOBC_Driver

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 11b08aacb01a9a39c6807928b35628e2c946369d
+ *          db commit hash: 91057002c3912105ba56ed1e91077ef6a4daf460
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
@@ -1,7 +1,7 @@
 /**
  * @file
- * @brief  コマンド定義
- * @note   このコードは自動生成されています！
+ * @brief コマンド定義
+ * @note  このコードは自動生成されています！
  */
 #ifndef AOBC_COMMAND_DEFINITIONS_H_
 #define AOBC_COMMAND_DEFINITIONS_H_

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: b652ed36ebcf0bf8e900adf444be970c6264bc04
+ *          db commit hash: 1903b95d5b784283e7dcf8dee8012b1ee9dd4fa3
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
@@ -2,6 +2,19 @@
  * @file
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
+ * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成パラメータ:
+ *          name:                    AOBC
+ *          db_prefix:               SAMPLE_AOBC
+ *          tlm_id_range:            0x90, 0xc0]
+ *          is_cmd_prefixed_in_db:   0
+ *          input_file_encoding:     utf-8
+ *          path_to_db:              ../examples/subobc/tlm-cmd-db/
+ *          max_tlm_num:             256
+ *          driver_path:             aocs/
+ *          driver_type:             AOBC_Driver
+ *          driver_name:             aobc_driver
+ *          code_when_tlm_not_found: aobc_driver->info.comm.rx_err_code = AOBC_RX_ERR_CODE_TLM_NOT_FOUND;
  */
 #ifndef AOBC_COMMAND_DEFINITIONS_H_
 #define AOBC_COMMAND_DEFINITIONS_H_

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: f7b24980106fed976f894ffd96608dfa24ad271d
+ *          db commit hash: 11b08aacb01a9a39c6807928b35628e2c946369d
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
@@ -5,11 +5,11 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
+ *          db commit hash: f7b24980106fed976f894ffd96608dfa24ad271d
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC
- *          tlm_id_range:            0x90, 0xc0]
+ *          tlm_id_range:            [0x90, 0xc0]
  *          is_cmd_prefixed_in_db:   0
  *          input_file_encoding:     utf-8
  *          max_tlm_num:             256

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
@@ -3,14 +3,15 @@
  * @file
  * @brief テレメトリバッファー（テレメ中継）
  * @note  このコードは自動生成されています！
- * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成 tlm-cmd-db:
+ *          repository:     arkedge/c2a-core
+ *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC
  *          tlm_id_range:            0x90, 0xc0]
  *          is_cmd_prefixed_in_db:   0
  *          input_file_encoding:     utf-8
- *          path_to_db:              ../examples/subobc/tlm-cmd-db/
  *          max_tlm_num:             256
  *          driver_path:             aocs/
  *          driver_type:             AOBC_Driver

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
@@ -3,6 +3,19 @@
  * @file
  * @brief テレメトリバッファー（テレメ中継）
  * @note  このコードは自動生成されています！
+ * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成パラメータ:
+ *          name:                    AOBC
+ *          db_prefix:               SAMPLE_AOBC
+ *          tlm_id_range:            0x90, 0xc0]
+ *          is_cmd_prefixed_in_db:   0
+ *          input_file_encoding:     utf-8
+ *          path_to_db:              ../examples/subobc/tlm-cmd-db/
+ *          max_tlm_num:             256
+ *          driver_path:             aocs/
+ *          driver_type:             AOBC_Driver
+ *          driver_name:             aobc_driver
+ *          code_when_tlm_not_found: aobc_driver->info.comm.rx_err_code = AOBC_RX_ERR_CODE_TLM_NOT_FOUND;
  */
 #include <src_core/component_driver/cdrv_common_tlm_cmd_packet.h>
 #include "./aobc_telemetry_definitions.h"

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: b652ed36ebcf0bf8e900adf444be970c6264bc04
+ *          db commit hash: 1903b95d5b784283e7dcf8dee8012b1ee9dd4fa3
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 11b08aacb01a9a39c6807928b35628e2c946369d
+ *          db commit hash: 91057002c3912105ba56ed1e91077ef6a4daf460
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
@@ -1,8 +1,8 @@
 #pragma section REPRO
 /**
  * @file
- * @brief  テレメトリバッファー（テレメ中継）
- * @note   このコードは自動生成されています！
+ * @brief テレメトリバッファー（テレメ中継）
+ * @note  このコードは自動生成されています！
  */
 #include <src_core/component_driver/cdrv_common_tlm_cmd_packet.h>
 #include "./aobc_telemetry_definitions.h"

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 91057002c3912105ba56ed1e91077ef6a4daf460
+ *          db commit hash: b652ed36ebcf0bf8e900adf444be970c6264bc04
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
@@ -2,14 +2,15 @@
  * @file
  * @brief テレメトリバッファー（テレメ中継）
  * @note  このコードは自動生成されています！
- * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成 tlm-cmd-db:
+ *          repository:     arkedge/c2a-core
+ *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC
  *          tlm_id_range:            0x90, 0xc0]
  *          is_cmd_prefixed_in_db:   0
  *          input_file_encoding:     utf-8
- *          path_to_db:              ../examples/subobc/tlm-cmd-db/
  *          max_tlm_num:             256
  *          driver_path:             aocs/
  *          driver_type:             AOBC_Driver

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: f7b24980106fed976f894ffd96608dfa24ad271d
+ *          db commit hash: 11b08aacb01a9a39c6807928b35628e2c946369d
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
@@ -4,11 +4,11 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
+ *          db commit hash: f7b24980106fed976f894ffd96608dfa24ad271d
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC
- *          tlm_id_range:            0x90, 0xc0]
+ *          tlm_id_range:            [0x90, 0xc0]
  *          is_cmd_prefixed_in_db:   0
  *          input_file_encoding:     utf-8
  *          max_tlm_num:             256

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 91057002c3912105ba56ed1e91077ef6a4daf460
+ *          db commit hash: b652ed36ebcf0bf8e900adf444be970c6264bc04
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
@@ -2,6 +2,19 @@
  * @file
  * @brief テレメトリバッファー（テレメ中継）
  * @note  このコードは自動生成されています！
+ * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成パラメータ:
+ *          name:                    AOBC
+ *          db_prefix:               SAMPLE_AOBC
+ *          tlm_id_range:            0x90, 0xc0]
+ *          is_cmd_prefixed_in_db:   0
+ *          input_file_encoding:     utf-8
+ *          path_to_db:              ../examples/subobc/tlm-cmd-db/
+ *          max_tlm_num:             256
+ *          driver_path:             aocs/
+ *          driver_type:             AOBC_Driver
+ *          driver_name:             aobc_driver
+ *          code_when_tlm_not_found: aobc_driver->info.comm.rx_err_code = AOBC_RX_ERR_CODE_TLM_NOT_FOUND;
  */
 #ifndef AOBC_TELEMETRY_BUFFER_H_
 #define AOBC_TELEMETRY_BUFFER_H_

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 11b08aacb01a9a39c6807928b35628e2c946369d
+ *          db commit hash: 91057002c3912105ba56ed1e91077ef6a4daf460
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
@@ -1,7 +1,7 @@
 /**
  * @file
- * @brief  テレメトリバッファー（テレメ中継）
- * @note   このコードは自動生成されています！
+ * @brief テレメトリバッファー（テレメ中継）
+ * @note  このコードは自動生成されています！
  */
 #ifndef AOBC_TELEMETRY_BUFFER_H_
 #define AOBC_TELEMETRY_BUFFER_H_

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: b652ed36ebcf0bf8e900adf444be970c6264bc04
+ *          db commit hash: 1903b95d5b784283e7dcf8dee8012b1ee9dd4fa3
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
@@ -1,7 +1,7 @@
 /**
  * @file
- * @brief  バッファリングされているテレメをパースしてMOBC内でかんたんに利用できるようにするためのテレメデータ構造体定義
- * @note   このコードは自動生成されています！
+ * @brief バッファリングされているテレメをパースしてMOBC内でかんたんに利用できるようにするためのテレメデータ構造体定義
+ * @note  このコードは自動生成されています！
  */
 #ifndef AOBC_TELEMETRY_DATA_DEFINITIONS_H_
 #define AOBC_TELEMETRY_DATA_DEFINITIONS_H_

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
@@ -2,14 +2,15 @@
  * @file
  * @brief バッファリングされているテレメをパースしてMOBC内でかんたんに利用できるようにするためのテレメデータ構造体定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成 tlm-cmd-db:
+ *          repository:     arkedge/c2a-core
+ *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC
  *          tlm_id_range:            0x90, 0xc0]
  *          is_cmd_prefixed_in_db:   0
  *          input_file_encoding:     utf-8
- *          path_to_db:              ../examples/subobc/tlm-cmd-db/
  *          max_tlm_num:             256
  *          driver_path:             aocs/
  *          driver_type:             AOBC_Driver

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
@@ -2,6 +2,19 @@
  * @file
  * @brief バッファリングされているテレメをパースしてMOBC内でかんたんに利用できるようにするためのテレメデータ構造体定義
  * @note  このコードは自動生成されています！
+ * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成パラメータ:
+ *          name:                    AOBC
+ *          db_prefix:               SAMPLE_AOBC
+ *          tlm_id_range:            0x90, 0xc0]
+ *          is_cmd_prefixed_in_db:   0
+ *          input_file_encoding:     utf-8
+ *          path_to_db:              ../examples/subobc/tlm-cmd-db/
+ *          max_tlm_num:             256
+ *          driver_path:             aocs/
+ *          driver_type:             AOBC_Driver
+ *          driver_name:             aobc_driver
+ *          code_when_tlm_not_found: aobc_driver->info.comm.rx_err_code = AOBC_RX_ERR_CODE_TLM_NOT_FOUND;
  */
 #ifndef AOBC_TELEMETRY_DATA_DEFINITIONS_H_
 #define AOBC_TELEMETRY_DATA_DEFINITIONS_H_

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: f7b24980106fed976f894ffd96608dfa24ad271d
+ *          db commit hash: 11b08aacb01a9a39c6807928b35628e2c946369d
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
@@ -4,11 +4,11 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
+ *          db commit hash: f7b24980106fed976f894ffd96608dfa24ad271d
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC
- *          tlm_id_range:            0x90, 0xc0]
+ *          tlm_id_range:            [0x90, 0xc0]
  *          is_cmd_prefixed_in_db:   0
  *          input_file_encoding:     utf-8
  *          max_tlm_num:             256

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 91057002c3912105ba56ed1e91077ef6a4daf460
+ *          db commit hash: b652ed36ebcf0bf8e900adf444be970c6264bc04
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 11b08aacb01a9a39c6807928b35628e2c946369d
+ *          db commit hash: 91057002c3912105ba56ed1e91077ef6a4daf460
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: b652ed36ebcf0bf8e900adf444be970c6264bc04
+ *          db commit hash: 1903b95d5b784283e7dcf8dee8012b1ee9dd4fa3
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
@@ -1,7 +1,7 @@
 /**
  * @file
- * @brief  テレメトリ定義
- * @note   このコードは自動生成されています！
+ * @brief テレメトリ定義
+ * @note  このコードは自動生成されています！
  */
 #ifndef AOBC_TELEMETRY_DEFINITIONS_H_
 #define AOBC_TELEMETRY_DEFINITIONS_H_

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
@@ -2,6 +2,19 @@
  * @file
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
+ * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成パラメータ:
+ *          name:                    AOBC
+ *          db_prefix:               SAMPLE_AOBC
+ *          tlm_id_range:            0x90, 0xc0]
+ *          is_cmd_prefixed_in_db:   0
+ *          input_file_encoding:     utf-8
+ *          path_to_db:              ../examples/subobc/tlm-cmd-db/
+ *          max_tlm_num:             256
+ *          driver_path:             aocs/
+ *          driver_type:             AOBC_Driver
+ *          driver_name:             aobc_driver
+ *          code_when_tlm_not_found: aobc_driver->info.comm.rx_err_code = AOBC_RX_ERR_CODE_TLM_NOT_FOUND;
  */
 #ifndef AOBC_TELEMETRY_DEFINITIONS_H_
 #define AOBC_TELEMETRY_DEFINITIONS_H_

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
@@ -2,14 +2,15 @@
  * @file
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成 tlm-cmd-db:
+ *          repository:     arkedge/c2a-core
+ *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC
  *          tlm_id_range:            0x90, 0xc0]
  *          is_cmd_prefixed_in_db:   0
  *          input_file_encoding:     utf-8
- *          path_to_db:              ../examples/subobc/tlm-cmd-db/
  *          max_tlm_num:             256
  *          driver_path:             aocs/
  *          driver_type:             AOBC_Driver

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: f7b24980106fed976f894ffd96608dfa24ad271d
+ *          db commit hash: 11b08aacb01a9a39c6807928b35628e2c946369d
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
@@ -4,11 +4,11 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
+ *          db commit hash: f7b24980106fed976f894ffd96608dfa24ad271d
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC
- *          tlm_id_range:            0x90, 0xc0]
+ *          tlm_id_range:            [0x90, 0xc0]
  *          is_cmd_prefixed_in_db:   0
  *          input_file_encoding:     utf-8
  *          max_tlm_num:             256

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 91057002c3912105ba56ed1e91077ef6a4daf460
+ *          db commit hash: b652ed36ebcf0bf8e900adf444be970c6264bc04
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 11b08aacb01a9a39c6807928b35628e2c946369d
+ *          db commit hash: 91057002c3912105ba56ed1e91077ef6a4daf460
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: b652ed36ebcf0bf8e900adf444be970c6264bc04
+ *          db commit hash: 1903b95d5b784283e7dcf8dee8012b1ee9dd4fa3
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: xxxx
+ *          db commit hash: 56c0502ad54caac8d6a9065dcb6fdbd6e913f3e9
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -3,8 +3,8 @@
  * @brief ブロックコマンド定義
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
- *          repository:     arkedge/c2a-core
- *          db commit hash: 56c0502ad54caac8d6a9065dcb6fdbd6e913f3e9
+ *          repository:    arkedge/c2a-core
+ *          db hash (MD5): e2120a2aaff3346ef5570adeda7a1cd6
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -2,6 +2,15 @@
  * @file
  * @brief ブロックコマンド定義
  * @note  このコードは自動生成されています！
+ * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成パラメータ:
+ *          path_to_src:           ../examples/mobc/src/
+ *          path_to_db:            ../examples/mobc/tlm-cmd-db/
+ *          db_prefix:             SAMPLE_MOBC
+ *          tlm_id_range:          [0x00, 0x100]
+ *          is_cmd_prefixed_in_db: 0
+ *          input_file_encoding:   utf-8
+ *          output_file_encoding:  utf-8
  */
 #ifndef BLOCK_COMMAND_DEFINITIONS_H_
 #define BLOCK_COMMAND_DEFINITIONS_H_

--- a/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
+ *          db commit hash: 
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -1,7 +1,7 @@
 /**
  * @file
- * @brief  ブロックコマンド定義
- * @note   このコードは自動生成されています！
+ * @brief ブロックコマンド定義
+ * @note  このコードは自動生成されています！
  */
 #ifndef BLOCK_COMMAND_DEFINITIONS_H_
 #define BLOCK_COMMAND_DEFINITIONS_H_

--- a/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -2,10 +2,10 @@
  * @file
  * @brief ブロックコマンド定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成 tlm-cmd-db:
+ *          repository:     arkedge/c2a-core
+ *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
  * @note  コード生成パラメータ:
- *          path_to_src:           ../examples/mobc/src/
- *          path_to_db:            ../examples/mobc/tlm-cmd-db/
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]
  *          is_cmd_prefixed_in_db: 0

--- a/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 
+ *          db commit hash: xxxx
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
@@ -1,8 +1,8 @@
 #pragma section REPRO
 /**
  * @file
- * @brief  コマンド定義
- * @note   このコードは自動生成されています！
+ * @brief コマンド定義
+ * @note  このコードは自動生成されています！
  */
 #include <src_core/tlm_cmd/command_analyze.h>
 #include "command_definitions.h"

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
@@ -3,10 +3,10 @@
  * @file
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成 tlm-cmd-db:
+ *          repository:     arkedge/c2a-core
+ *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
  * @note  コード生成パラメータ:
- *          path_to_src:           ../examples/mobc/src/
- *          path_to_db:            ../examples/mobc/tlm-cmd-db/
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]
  *          is_cmd_prefixed_in_db: 0

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
@@ -3,6 +3,15 @@
  * @file
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
+ * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成パラメータ:
+ *          path_to_src:           ../examples/mobc/src/
+ *          path_to_db:            ../examples/mobc/tlm-cmd-db/
+ *          db_prefix:             SAMPLE_MOBC
+ *          tlm_id_range:          [0x00, 0x100]
+ *          is_cmd_prefixed_in_db: 0
+ *          input_file_encoding:   utf-8
+ *          output_file_encoding:  utf-8
  */
 #include <src_core/tlm_cmd/command_analyze.h>
 #include "command_definitions.h"

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: xxxx
+ *          db commit hash: 56c0502ad54caac8d6a9065dcb6fdbd6e913f3e9
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
@@ -4,8 +4,8 @@
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
- *          repository:     arkedge/c2a-core
- *          db commit hash: 56c0502ad54caac8d6a9065dcb6fdbd6e913f3e9
+ *          repository:    arkedge/c2a-core
+ *          db hash (MD5): e2120a2aaff3346ef5570adeda7a1cd6
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
+ *          db commit hash: 
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 
+ *          db commit hash: xxxx
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
@@ -1,7 +1,7 @@
 /**
  * @file
- * @brief  コマンド定義
- * @note   このコードは自動生成されています！
+ * @brief コマンド定義
+ * @note  このコードは自動生成されています！
  */
 #ifndef COMMAND_DEFINITIONS_H_
 #define COMMAND_DEFINITIONS_H_

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: xxxx
+ *          db commit hash: 56c0502ad54caac8d6a9065dcb6fdbd6e913f3e9
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
+ *          db commit hash: 
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
@@ -3,8 +3,8 @@
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
- *          repository:     arkedge/c2a-core
- *          db commit hash: 56c0502ad54caac8d6a9065dcb6fdbd6e913f3e9
+ *          repository:    arkedge/c2a-core
+ *          db hash (MD5): e2120a2aaff3346ef5570adeda7a1cd6
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
@@ -2,10 +2,10 @@
  * @file
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成 tlm-cmd-db:
+ *          repository:     arkedge/c2a-core
+ *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
  * @note  コード生成パラメータ:
- *          path_to_src:           ../examples/mobc/src/
- *          path_to_db:            ../examples/mobc/tlm-cmd-db/
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]
  *          is_cmd_prefixed_in_db: 0

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 
+ *          db commit hash: xxxx
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
@@ -2,6 +2,15 @@
  * @file
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
+ * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成パラメータ:
+ *          path_to_src:           ../examples/mobc/src/
+ *          path_to_db:            ../examples/mobc/tlm-cmd-db/
+ *          db_prefix:             SAMPLE_MOBC
+ *          tlm_id_range:          [0x00, 0x100]
+ *          is_cmd_prefixed_in_db: 0
+ *          input_file_encoding:   utf-8
+ *          output_file_encoding:  utf-8
  */
 #ifndef COMMAND_DEFINITIONS_H_
 #define COMMAND_DEFINITIONS_H_

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -3,10 +3,10 @@
  * @file
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成 tlm-cmd-db:
+ *          repository:     arkedge/c2a-core
+ *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
  * @note  コード生成パラメータ:
- *          path_to_src:           ../examples/mobc/src/
- *          path_to_db:            ../examples/mobc/tlm-cmd-db/
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]
  *          is_cmd_prefixed_in_db: 0

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -3,6 +3,15 @@
  * @file
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
+ * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成パラメータ:
+ *          path_to_src:           ../examples/mobc/src/
+ *          path_to_db:            ../examples/mobc/tlm-cmd-db/
+ *          db_prefix:             SAMPLE_MOBC
+ *          tlm_id_range:          [0x00, 0x100]
+ *          is_cmd_prefixed_in_db: 0
+ *          input_file_encoding:   utf-8
+ *          output_file_encoding:  utf-8
  */
 #include <src_core/tlm_cmd/telemetry_frame.h>
 #include "telemetry_definitions.h"

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: xxxx
+ *          db commit hash: 56c0502ad54caac8d6a9065dcb6fdbd6e913f3e9
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
+ *          db commit hash: 
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -1,8 +1,8 @@
 #pragma section REPRO
 /**
  * @file
- * @brief  テレメトリ定義
- * @note   このコードは自動生成されています！
+ * @brief テレメトリ定義
+ * @note  このコードは自動生成されています！
  */
 #include <src_core/tlm_cmd/telemetry_frame.h>
 #include "telemetry_definitions.h"

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 
+ *          db commit hash: xxxx
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -4,8 +4,8 @@
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
- *          repository:     arkedge/c2a-core
- *          db commit hash: 56c0502ad54caac8d6a9065dcb6fdbd6e913f3e9
+ *          repository:    arkedge/c2a-core
+ *          db hash (MD5): e2120a2aaff3346ef5570adeda7a1cd6
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: xxxx
+ *          db commit hash: 56c0502ad54caac8d6a9065dcb6fdbd6e913f3e9
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
+ *          db commit hash: 
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -2,6 +2,15 @@
  * @file
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
+ * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成パラメータ:
+ *          path_to_src:           ../examples/mobc/src/
+ *          path_to_db:            ../examples/mobc/tlm-cmd-db/
+ *          db_prefix:             SAMPLE_MOBC
+ *          tlm_id_range:          [0x00, 0x100]
+ *          is_cmd_prefixed_in_db: 0
+ *          input_file_encoding:   utf-8
+ *          output_file_encoding:  utf-8
  */
 #ifndef TELEMETRY_DEFINITIONS_H_
 #define TELEMETRY_DEFINITIONS_H_

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -1,7 +1,7 @@
 /**
  * @file
- * @brief  テレメトリ定義
- * @note   このコードは自動生成されています！
+ * @brief テレメトリ定義
+ * @note  このコードは自動生成されています！
  */
 #ifndef TELEMETRY_DEFINITIONS_H_
 #define TELEMETRY_DEFINITIONS_H_

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -3,8 +3,8 @@
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
- *          repository:     arkedge/c2a-core
- *          db commit hash: 56c0502ad54caac8d6a9065dcb6fdbd6e913f3e9
+ *          repository:    arkedge/c2a-core
+ *          db hash (MD5): e2120a2aaff3346ef5570adeda7a1cd6
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -2,10 +2,10 @@
  * @file
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成 tlm-cmd-db:
+ *          repository:     arkedge/c2a-core
+ *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
  * @note  コード生成パラメータ:
- *          path_to_src:           ../examples/mobc/src/
- *          path_to_db:            ../examples/mobc/tlm-cmd-db/
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]
  *          is_cmd_prefixed_in_db: 0

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 
+ *          db commit hash: xxxx
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: xxxx
+ *          db commit hash: e28c5f3a45187e8b9202b363b27e162713a6bc28
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -2,6 +2,15 @@
  * @file
  * @brief ブロックコマンド定義
  * @note  このコードは自動生成されています！
+ * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成パラメータ:
+ *          path_to_src:           ../examples/subobc/src/
+ *          path_to_db:            ../examples/subobc/tlm-cmd-db/
+ *          db_prefix:             SAMPLE_AOBC
+ *          tlm_id_range:          [0x00, 0x100]
+ *          is_cmd_prefixed_in_db: 0
+ *          input_file_encoding:   utf-8
+ *          output_file_encoding:  utf-8
  */
 #ifndef BLOCK_COMMAND_DEFINITIONS_H_
 #define BLOCK_COMMAND_DEFINITIONS_H_

--- a/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -1,7 +1,7 @@
 /**
  * @file
- * @brief  ブロックコマンド定義
- * @note   このコードは自動生成されています！
+ * @brief ブロックコマンド定義
+ * @note  このコードは自動生成されています！
  */
 #ifndef BLOCK_COMMAND_DEFINITIONS_H_
 #define BLOCK_COMMAND_DEFINITIONS_H_

--- a/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -3,8 +3,8 @@
  * @brief ブロックコマンド定義
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
- *          repository:     arkedge/c2a-core
- *          db commit hash: e28c5f3a45187e8b9202b363b27e162713a6bc28
+ *          repository:    arkedge/c2a-core
+ *          db hash (MD5): a68cdf10ca467fd750b1d988780fcb5b
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
+ *          db commit hash: 
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 
+ *          db commit hash: xxxx
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -2,10 +2,10 @@
  * @file
  * @brief ブロックコマンド定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成 tlm-cmd-db:
+ *          repository:     arkedge/c2a-core
+ *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
  * @note  コード生成パラメータ:
- *          path_to_src:           ../examples/subobc/src/
- *          path_to_db:            ../examples/subobc/tlm-cmd-db/
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]
  *          is_cmd_prefixed_in_db: 0

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
@@ -1,8 +1,8 @@
 #pragma section REPRO
 /**
  * @file
- * @brief  コマンド定義
- * @note   このコードは自動生成されています！
+ * @brief コマンド定義
+ * @note  このコードは自動生成されています！
  */
 #include <src_core/tlm_cmd/command_analyze.h>
 #include "command_definitions.h"

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 
+ *          db commit hash: xxxx
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
@@ -3,10 +3,10 @@
  * @file
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成 tlm-cmd-db:
+ *          repository:     arkedge/c2a-core
+ *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
  * @note  コード生成パラメータ:
- *          path_to_src:           ../examples/subobc/src/
- *          path_to_db:            ../examples/subobc/tlm-cmd-db/
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]
  *          is_cmd_prefixed_in_db: 0

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
@@ -3,6 +3,15 @@
  * @file
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
+ * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成パラメータ:
+ *          path_to_src:           ../examples/subobc/src/
+ *          path_to_db:            ../examples/subobc/tlm-cmd-db/
+ *          db_prefix:             SAMPLE_AOBC
+ *          tlm_id_range:          [0x00, 0x100]
+ *          is_cmd_prefixed_in_db: 0
+ *          input_file_encoding:   utf-8
+ *          output_file_encoding:  utf-8
  */
 #include <src_core/tlm_cmd/command_analyze.h>
 #include "command_definitions.h"

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
@@ -4,8 +4,8 @@
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
- *          repository:     arkedge/c2a-core
- *          db commit hash: e28c5f3a45187e8b9202b363b27e162713a6bc28
+ *          repository:    arkedge/c2a-core
+ *          db hash (MD5): a68cdf10ca467fd750b1d988780fcb5b
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: xxxx
+ *          db commit hash: e28c5f3a45187e8b9202b363b27e162713a6bc28
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
+ *          db commit hash: 
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
@@ -1,7 +1,7 @@
 /**
  * @file
- * @brief  コマンド定義
- * @note   このコードは自動生成されています！
+ * @brief コマンド定義
+ * @note  このコードは自動生成されています！
  */
 #ifndef COMMAND_DEFINITIONS_H_
 #define COMMAND_DEFINITIONS_H_

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
@@ -2,10 +2,10 @@
  * @file
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成 tlm-cmd-db:
+ *          repository:     arkedge/c2a-core
+ *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
  * @note  コード生成パラメータ:
- *          path_to_src:           ../examples/subobc/src/
- *          path_to_db:            ../examples/subobc/tlm-cmd-db/
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]
  *          is_cmd_prefixed_in_db: 0

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: xxxx
+ *          db commit hash: e28c5f3a45187e8b9202b363b27e162713a6bc28
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
@@ -2,6 +2,15 @@
  * @file
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
+ * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成パラメータ:
+ *          path_to_src:           ../examples/subobc/src/
+ *          path_to_db:            ../examples/subobc/tlm-cmd-db/
+ *          db_prefix:             SAMPLE_AOBC
+ *          tlm_id_range:          [0x00, 0x100]
+ *          is_cmd_prefixed_in_db: 0
+ *          input_file_encoding:   utf-8
+ *          output_file_encoding:  utf-8
  */
 #ifndef COMMAND_DEFINITIONS_H_
 #define COMMAND_DEFINITIONS_H_

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
+ *          db commit hash: 
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 
+ *          db commit hash: xxxx
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
@@ -3,8 +3,8 @@
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
- *          repository:     arkedge/c2a-core
- *          db commit hash: e28c5f3a45187e8b9202b363b27e162713a6bc28
+ *          repository:    arkedge/c2a-core
+ *          db hash (MD5): a68cdf10ca467fd750b1d988780fcb5b
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 
+ *          db commit hash: xxxx
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -3,10 +3,10 @@
  * @file
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成 tlm-cmd-db:
+ *          repository:     arkedge/c2a-core
+ *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
  * @note  コード生成パラメータ:
- *          path_to_src:           ../examples/subobc/src/
- *          path_to_db:            ../examples/subobc/tlm-cmd-db/
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]
  *          is_cmd_prefixed_in_db: 0

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -3,6 +3,15 @@
  * @file
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
+ * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成パラメータ:
+ *          path_to_src:           ../examples/subobc/src/
+ *          path_to_db:            ../examples/subobc/tlm-cmd-db/
+ *          db_prefix:             SAMPLE_AOBC
+ *          tlm_id_range:          [0x00, 0x100]
+ *          is_cmd_prefixed_in_db: 0
+ *          input_file_encoding:   utf-8
+ *          output_file_encoding:  utf-8
  */
 #include <src_core/tlm_cmd/telemetry_frame.h>
 #include "telemetry_definitions.h"

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: xxxx
+ *          db commit hash: e28c5f3a45187e8b9202b363b27e162713a6bc28
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -1,8 +1,8 @@
 #pragma section REPRO
 /**
  * @file
- * @brief  テレメトリ定義
- * @note   このコードは自動生成されています！
+ * @brief テレメトリ定義
+ * @note  このコードは自動生成されています！
  */
 #include <src_core/tlm_cmd/telemetry_frame.h>
 #include "telemetry_definitions.h"

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -4,8 +4,8 @@
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
- *          repository:     arkedge/c2a-core
- *          db commit hash: e28c5f3a45187e8b9202b363b27e162713a6bc28
+ *          repository:    arkedge/c2a-core
+ *          db hash (MD5): a68cdf10ca467fd750b1d988780fcb5b
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
+ *          db commit hash: 
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: xxxx
+ *          db commit hash: e28c5f3a45187e8b9202b363b27e162713a6bc28
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -2,10 +2,10 @@
  * @file
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成 tlm-cmd-db:
+ *          repository:     arkedge/c2a-core
+ *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
  * @note  コード生成パラメータ:
- *          path_to_src:           ../examples/subobc/src/
- *          path_to_db:            ../examples/subobc/tlm-cmd-db/
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]
  *          is_cmd_prefixed_in_db: 0

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 58ecdef00f908ac19f3512a1155eaef65244cd81
+ *          db commit hash: 
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -3,8 +3,8 @@
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
- *          repository:     arkedge/c2a-core
- *          db commit hash: e28c5f3a45187e8b9202b363b27e162713a6bc28
+ *          repository:    arkedge/c2a-core
+ *          db hash (MD5): a68cdf10ca467fd750b1d988780fcb5b
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成 tlm-cmd-db:
  *          repository:     arkedge/c2a-core
- *          db commit hash: 
+ *          db commit hash: xxxx
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -1,7 +1,7 @@
 /**
  * @file
- * @brief  テレメトリ定義
- * @note   このコードは自動生成されています！
+ * @brief テレメトリ定義
+ * @note  このコードは自動生成されています！
  */
 #ifndef TELEMETRY_DEFINITIONS_H_
 #define TELEMETRY_DEFINITIONS_H_

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -2,6 +2,15 @@
  * @file
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
+ * @note  コード生成 db commit hash: ec4ce770d07fb3fa6824f36bd8d5253895174240
+ * @note  コード生成パラメータ:
+ *          path_to_src:           ../examples/subobc/src/
+ *          path_to_db:            ../examples/subobc/tlm-cmd-db/
+ *          db_prefix:             SAMPLE_AOBC
+ *          tlm_id_range:          [0x00, 0x100]
+ *          is_cmd_prefixed_in_db: 0
+ *          input_file_encoding:   utf-8
+ *          output_file_encoding:  utf-8
  */
 #ifndef TELEMETRY_DEFINITIONS_H_
 #define TELEMETRY_DEFINITIONS_H_


### PR DESCRIPTION
## 概要
自動生成コードの @note に，生成元DBのコミットハッシュと生成パラメータを出力する．
これによって，生成されたコードから，元のDBや生成パラメータがわかるようになる

自身のdbから生成されたコードには，そのdbに含まれるすべてのcsvのmd5を結合したものをさらにmd5にしたもの，
sub obcのdbについては，そのコミットハッシュを記録している．

## Issue
NA

## 検証結果
CIが通ればOK

## 影響範囲
- code generator をかけたかどうかを判断するCIにも修正が必要
- 該当repositoryのtlm-cmd-dbについては，最新版のdbとコードが同期されていることが重要だが，MOBCに含まれるsub obcのdbについては，多くが外部repositoryであり，また常に最新版とは限らないので，CIではチェックを除外した