### PR TITLE
node_modules を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ examples/subobc/src/src_core
 examples/subobc/build
 *.pyc
 tlmcmddb*.json
+node_modules/
 
 # Added by cargo
 /target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Fixed
 
-- [#246](https://github.com/arkedge/c2a-core/pull/246): node_modules を .gitignore に追加
+- [#246](https://github.com/arkedge/c2a-core/pull/246): `node_modules` を `.gitignore` に追加
 
 ### Migration Guide
 - [#240](https://github.com/arkedge/c2a-core/pull/240): user 側でのコードレベルでの対応は不要

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - [#245](https://github.com/arkedge/c2a-core/pull/245): memory dump application のリファクタリング
 
+### Fixed
+
+- [#246](https://github.com/arkedge/c2a-core/pull/246): node_modules を .gitignore に追加
+
 ### Migration Guide
 - [#240](https://github.com/arkedge/c2a-core/pull/240): user 側でのコードレベルでの対応は不要
   - 新しい code-generator で生成したコードは，既存のものと diff が発生するため，改めてコード生成し直すとよい．


### PR DESCRIPTION
## 概要
c2a user でデバッグするときに， `npm install` を実行することになるため

