### PR TITLE
Refactor code-generator

### DIFF
--- a/.github/workflows/check_code_generation.yml
+++ b/.github/workflows/check_code_generation.yml
@@ -21,10 +21,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
 
-      - name: run code-generator
+      - name: prepare code-generator settings
         working-directory: ./code-generator
         run: |
           cp "./settings_${{ matrix.user }}.json" ./settings.json
+
+      # FIXME: subobc の生成コードには commit hash が焼かれていて現状だと diff が出てしまうため，とりあえずスキップする
+      - name: skip subobc code generation
+        working-directory: ./code-generator
+        run: |
+          jq '.is_main_obc = 0' < settings.json > settings_tmp.json
+          mv settings_tmp.json settings.json
+
+
+      - name: run code-generator
+        working-directory: ./code-generator
+        run: |
           python GenerateC2ACode.py
 
       - name: check diff

--- a/.github/workflows/check_code_generation.yml
+++ b/.github/workflows/check_code_generation.yml
@@ -25,8 +25,6 @@ jobs:
         working-directory: ./code-generator
         run: |
           cp "./settings_${{ matrix.user }}.json" ./settings.json
-          # sub obc の tlm cmd db は見ない
-          sed -i 's/  "is_main_obc" : 1,/  "is_main_obc" : 0,/g' ./settings.json
           python GenerateC2ACode.py
 
       - name: check diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 注意: これは既存の C2A core update の「リリースの間の Pull Request を眺めてなんとなく察する」という曖昧な操作を緩和していくための試みであり，C2A user に対するお知らせを行う場として使っていくことを意図しています．初めから c2a-core の全変更を取り扱うと不必要に煩雑になるだけになってしまうため，完全な変更内容の一覧についてはこれまで通り [GitHub Releases](https://github.com/arkedge/c2a-core/releases) などから参照してください．
 
-## v4.2.0 (Unreleased-12-11)
+## v4.2.0 (Unreleased)
 
 ### Enhancements
 - [#240](https://github.com/arkedge/c2a-core/pull/240): code-generator の出力コードに，設定情報を残すようにする

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -144,12 +144,6 @@ def CalcMd5_(path):
     content_lf = content.replace("\r\n", "\n")
     return hashlib.md5(content_lf.encode("utf-8")).hexdigest()
 
-    hash_md5 = hashlib.md5()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(4096), b""):
-            hash_md5.update(chunk)
-    return hash_md5.hexdigest()
-
 
 def FindCsvFilesAndCalculateMd5_(path):
     csv_files_info = []

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -18,8 +18,6 @@ def GenerateSettingNote(settings):
     note += GetRepo_(settings["path_to_db"])
     note += "\n"
     note += " *          CSV files MD5: "
-    # note += GetCommitHash_(settings["path_to_db"])
-    # note += GetLatestDirCommitHash_(settings["path_to_db"])
     note += GetDbHash_(settings["path_to_db"])
     note += "\n"
     note += " * @note  コード生成パラメータ:\n"
@@ -52,6 +50,9 @@ def GenerateSubObcSettingNote(settings, obc_idx):
     note += " * @note  コード生成元 tlm-cmd-db:\n"
     note += " *          repository:     "
     note += GetRepo_(sub_obc_settings["path_to_db"])
+    note += "\n"
+    note += " *          CSV files MD5: "
+    note += GetDbHash_(settings["path_to_db"])
     note += "\n"
     note += " *          db commit hash: "
     note += GetCommitHash_(sub_obc_settings["path_to_db"])

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -74,7 +74,7 @@ def GetCommitHash_(path):
         )
         return result.stdout.strip()
     except subprocess.CalledProcessError:
-        print("failed to get commit hash(" + path + ")")
+        print("Warn: failed to get commit hash(" + path + ")", file=sys.stderr)
         return "unknown"
 
 
@@ -92,7 +92,7 @@ def GetRepo_(path):
     try:
         subprocess.run(["git", "--version"], capture_output=True, check=True)
     except subprocess.CalledProcessError:
-        print("failed to execute git command", file=sys.stderr)
+        print("Warn: failed to execute git command", file=sys.stderr)
         return "unknown/unknown/unknown"
 
     try:
@@ -102,7 +102,7 @@ def GetRepo_(path):
         remote = result.stdout.split("\n")[0]  # 最初の remote を取得
 
         if not remote:
-            print("failed to get git remote", file=sys.stderr)
+            print("Warn: failed to get git remote", file=sys.stderr)
             return "unknown/unknown/unknown"
 
         remote_url = subprocess.run(
@@ -124,7 +124,7 @@ def GetRepo_(path):
 
         return remote_url
     except subprocess.CalledProcessError:
-        print("failed to execute: git remote", file=sys.stderr)
+        print("Warn: failed to execute: git remote", file=sys.stderr)
         return "unknown/unknown/unknown"
 
 

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -42,17 +42,27 @@ def GenerateSubObcSettingNote(settings, obc_idx):
     note += " * @note  コード生成パラメータ:\n"
     note += " *          name:                    " + sub_obc_settings["name"] + "\n"
     note += " *          db_prefix:               " + sub_obc_settings["db_prefix"] + "\n"
-    note += " *          tlm_id_range:            "
     note += (
-        "[" + sub_obc_settings["tlm_id_range"][0] + ", " + sub_obc_settings["tlm_id_range"][1] + "]\n"
+        " *          tlm_id_range:            "
+        + "["
+        + sub_obc_settings["tlm_id_range"][0]
+        + ", "
+        + sub_obc_settings["tlm_id_range"][1]
+        + "]\n"
     )
-    note += " *          is_cmd_prefixed_in_db:   " + str(sub_obc_settings["is_cmd_prefixed_in_db"]) + "\n"
+    note += (
+        " *          is_cmd_prefixed_in_db:   "
+        + str(sub_obc_settings["is_cmd_prefixed_in_db"])
+        + "\n"
+    )
     note += " *          input_file_encoding:     " + sub_obc_settings["input_file_encoding"] + "\n"
     note += " *          max_tlm_num:             " + str(sub_obc_settings["max_tlm_num"]) + "\n"
     note += " *          driver_path:             " + sub_obc_settings["driver_path"] + "\n"
     note += " *          driver_type:             " + sub_obc_settings["driver_type"] + "\n"
     note += " *          driver_name:             " + sub_obc_settings["driver_name"] + "\n"
-    note += " *          code_when_tlm_not_found: " + sub_obc_settings["code_when_tlm_not_found"] + "\n"
+    note += (
+        " *          code_when_tlm_not_found: " + sub_obc_settings["code_when_tlm_not_found"] + "\n"
+    )
     # path_to_db については，実行環境によって異なるので出力しない
 
     return note
@@ -68,11 +78,13 @@ def GetCommitHash_(path):
         print("failed to get commit hash(" + path + ")")
         return "unknown"
 
+
 # Python 3.8 には str.removeprefix() が無い
 def RemovePrefix_(text, prefix):
     if text.startswith(prefix):
-        text = text[len(prefix):]
+        text = text[len(prefix) :]
     return text
+
 
 def GetRepo_(path):
     # GitHub などの場合: github.com/user/repo のようにする
@@ -95,13 +107,17 @@ def GetRepo_(path):
             return "unknown/unknown/unknown"
 
         remote_url = subprocess.run(
-            ["git", "remote", "get-url", remote], cwd=path, text=True, capture_output=True, check=True
+            ["git", "remote", "get-url", remote],
+            cwd=path,
+            text=True,
+            capture_output=True,
+            check=True,
         ).stdout
 
         # HTTPS と SSH の remote URL の差異を吸収（削除）
         remote_url = RemovePrefix_(remote_url, "git@")
         remote_url = RemovePrefix_(remote_url, "https://")
-        remote_url = remote_url.replace(':', '/')
+        remote_url = remote_url.replace(":", "/")
 
         # URLの末尾に.gitがなければ追加
         if not remote_url.endswith(".git"):

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -36,7 +36,7 @@ def GenerateSubObcSettingNote(settings, obc_idx):
     note += " * @note  コード生成元 tlm-cmd-db:\n"
     note += " *          repository:     "
     note += GetRepo_(sub_obc_settings["path_to_db"]) + "\n"
-    note += " *          CSV files MD5: " + GetDbHash_(settings["path_to_db"]) + "\n"
+    note += " *          CSV files MD5:  " + GetDbHash_(settings["path_to_db"]) + "\n"
     note += " *          db commit hash: " + GetCommitHash_(sub_obc_settings["path_to_db"]) + "\n"
     note += " * @note  コード生成パラメータ:\n"
     note += " *          name:                    " + sub_obc_settings["name"] + "\n"

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -4,7 +4,6 @@ util
 """
 
 import subprocess
-import re
 import sys
 import os
 import hashlib
@@ -92,7 +91,7 @@ def GetRepo_(path):
 
     try:
         subprocess.run(["git", "--version"], capture_output=True, check=True)
-    except:
+    except subprocess.CalledProcessError:
         print("failed to execute git command", file=sys.stderr)
         return "unknown/unknown/unknown"
 

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -12,11 +12,11 @@ import hashlib
 def GenerateSettingNote(settings):
     note = ""
     note += " * @note  このコードは自動生成されています！\n"
-    note += " * @note  コード生成 tlm-cmd-db:\n"
+    note += " * @note  コード生成元 tlm-cmd-db:\n"
     note += " *          repository:    "
     note += GetRepoName_(settings["path_to_db"])
     note += "\n"
-    note += " *          db hash (MD5): "
+    note += " *          CSV files MD5: "
     # note += GetCommitHash_(settings["path_to_db"])
     # note += GetLatestDirCommitHash_(settings["path_to_db"])
     note += GetDbHash_(settings["path_to_db"])
@@ -48,7 +48,7 @@ def GenerateSubObcSettingNote(settings, obc_idx):
 
     note = ""
     note += " * @note  このコードは自動生成されています！\n"
-    note += " * @note  コード生成 tlm-cmd-db:\n"
+    note += " * @note  コード生成元 tlm-cmd-db:\n"
     note += " *          repository:     "
     note += GetRepoName_(sub_obc_settings["path_to_db"])
     note += "\n"

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -137,11 +137,12 @@ def GetDbHash_(path):
 
 
 def CalcMd5_(path):
-    # 改行コード問題がうざいので，全部 CRLF に変換して計算
+    # Windows 環境で改行コードが CRLF になっているとハッシュ値が変わってしまう
+    # そのため，MD5 の計算は CRLF -> LF してから行う
     with open(path, "r", encoding="utf-8") as file:
         content = file.read()
-    content_crlf = content.replace("\n", "\r\n")
-    return hashlib.md5(content_crlf.encode("utf-8")).hexdigest()
+    content_lf = content.replace("\r\n", "\n")
+    return hashlib.md5(content_lf.encode("utf-8")).hexdigest()
 
     hash_md5 = hashlib.md5()
     with open(path, "rb") as f:

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -111,7 +111,7 @@ def GetRepo_(path):
             text=True,
             capture_output=True,
             check=True,
-        ).stdout
+        ).stdout.strip()
 
         # HTTPS と SSH の remote URL の差異を吸収（削除）
         remote_url = RemovePrefix_(remote_url, "git@")

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -14,28 +14,15 @@ def GenerateSettingNote(settings):
     note = ""
     note += " * @note  このコードは自動生成されています！\n"
     note += " * @note  コード生成元 tlm-cmd-db:\n"
-    note += " *          repository:    "
-    note += GetRepo_(settings["path_to_db"])
-    note += "\n"
-    note += " *          CSV files MD5: "
-    note += GetDbHash_(settings["path_to_db"])
-    note += "\n"
+    note += " *          repository:    " + GetRepo_(settings["path_to_db"]) + "\n"
+    note += " *          CSV files MD5: " + GetDbHash_(settings["path_to_db"]) + "\n"
     note += " * @note  コード生成パラメータ:\n"
-    note += " *          db_prefix:             "
-    note += settings["db_prefix"]
-    note += "\n"
+    note += " *          db_prefix:             " + settings["db_prefix"] + "\n"
     note += " *          tlm_id_range:          "
-    note += "[" + settings["tlm_id_range"][0] + ", " + settings["tlm_id_range"][1] + "]"
-    note += "\n"
-    note += " *          is_cmd_prefixed_in_db: "
-    note += str(settings["is_cmd_prefixed_in_db"])
-    note += "\n"
-    note += " *          input_file_encoding:   "
-    note += settings["input_file_encoding"]
-    note += "\n"
-    note += " *          output_file_encoding:  "
-    note += settings["output_file_encoding"]
-    note += "\n"
+    note += "[" + settings["tlm_id_range"][0] + ", " + settings["tlm_id_range"][1] + "]\n"
+    note += " *          is_cmd_prefixed_in_db: " + str(settings["is_cmd_prefixed_in_db"]) + "\n"
+    note += " *          input_file_encoding:   " + settings["input_file_encoding"] + "\n"
+    note += " *          output_file_encoding:  " + settings["output_file_encoding"] + "\n"
     # is_main_obc については，生成状況によって異なるので出力しない
     # path_to_src, path_to_db については，実行環境によって異なるので出力しない
 
@@ -49,47 +36,23 @@ def GenerateSubObcSettingNote(settings, obc_idx):
     note += " * @note  このコードは自動生成されています！\n"
     note += " * @note  コード生成元 tlm-cmd-db:\n"
     note += " *          repository:     "
-    note += GetRepo_(sub_obc_settings["path_to_db"])
-    note += "\n"
-    note += " *          CSV files MD5: "
-    note += GetDbHash_(settings["path_to_db"])
-    note += "\n"
-    note += " *          db commit hash: "
-    note += GetCommitHash_(sub_obc_settings["path_to_db"])
-    note += "\n"
+    note += GetRepo_(sub_obc_settings["path_to_db"]) + "\n"
+    note += " *          CSV files MD5: " + GetDbHash_(settings["path_to_db"]) + "\n"
+    note += " *          db commit hash: " + GetCommitHash_(sub_obc_settings["path_to_db"]) + "\n"
     note += " * @note  コード生成パラメータ:\n"
-    note += " *          name:                    "
-    note += sub_obc_settings["name"]
-    note += "\n"
-    note += " *          db_prefix:               "
-    note += sub_obc_settings["db_prefix"]
-    note += "\n"
+    note += " *          name:                    " + sub_obc_settings["name"] + "\n"
+    note += " *          db_prefix:               " + sub_obc_settings["db_prefix"] + "\n"
     note += " *          tlm_id_range:            "
     note += (
-        "[" + sub_obc_settings["tlm_id_range"][0] + ", " + sub_obc_settings["tlm_id_range"][1] + "]"
+        "[" + sub_obc_settings["tlm_id_range"][0] + ", " + sub_obc_settings["tlm_id_range"][1] + "]\n"
     )
-    note += "\n"
-    note += " *          is_cmd_prefixed_in_db:   "
-    note += str(sub_obc_settings["is_cmd_prefixed_in_db"])
-    note += "\n"
-    note += " *          input_file_encoding:     "
-    note += sub_obc_settings["input_file_encoding"]
-    note += "\n"
-    note += " *          max_tlm_num:             "
-    note += str(sub_obc_settings["max_tlm_num"])
-    note += "\n"
-    note += " *          driver_path:             "
-    note += sub_obc_settings["driver_path"]
-    note += "\n"
-    note += " *          driver_type:             "
-    note += sub_obc_settings["driver_type"]
-    note += "\n"
-    note += " *          driver_name:             "
-    note += sub_obc_settings["driver_name"]
-    note += "\n"
-    note += " *          code_when_tlm_not_found: "
-    note += sub_obc_settings["code_when_tlm_not_found"]
-    note += "\n"
+    note += " *          is_cmd_prefixed_in_db:   " + str(sub_obc_settings["is_cmd_prefixed_in_db"]) + "\n"
+    note += " *          input_file_encoding:     " + sub_obc_settings["input_file_encoding"] + "\n"
+    note += " *          max_tlm_num:             " + str(sub_obc_settings["max_tlm_num"]) + "\n"
+    note += " *          driver_path:             " + sub_obc_settings["driver_path"] + "\n"
+    note += " *          driver_type:             " + sub_obc_settings["driver_type"] + "\n"
+    note += " *          driver_name:             " + sub_obc_settings["driver_name"] + "\n"
+    note += " *          code_when_tlm_not_found: " + sub_obc_settings["code_when_tlm_not_found"] + "\n"
     # path_to_db については，実行環境によって異なるので出力しない
 
     return note

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
@@ -2,9 +2,10 @@
  * @file
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 tlm-cmd-db:
- *          repository:     arkedge/c2a-core
- *          db commit hash: 91e336f10d6789c2e85d9acf48d91e3341c25229
+ * @note  コード生成元 tlm-cmd-db:
+ *          repository:     github.com/arkedge/c2a-core.git
+ *          CSV files MD5:  5da53df42b35605f4b54affc4a518dd7
+ *          db commit hash: 9ed588f4feffa93b4530d7677111ee0ca28247d6
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
@@ -3,9 +3,10 @@
  * @file
  * @brief テレメトリバッファー（テレメ中継）
  * @note  このコードは自動生成されています！
- * @note  コード生成 tlm-cmd-db:
- *          repository:     arkedge/c2a-core
- *          db commit hash: 91e336f10d6789c2e85d9acf48d91e3341c25229
+ * @note  コード生成元 tlm-cmd-db:
+ *          repository:     github.com/arkedge/c2a-core.git
+ *          CSV files MD5:  5da53df42b35605f4b54affc4a518dd7
+ *          db commit hash: 9ed588f4feffa93b4530d7677111ee0ca28247d6
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
@@ -2,9 +2,10 @@
  * @file
  * @brief テレメトリバッファー（テレメ中継）
  * @note  このコードは自動生成されています！
- * @note  コード生成 tlm-cmd-db:
- *          repository:     arkedge/c2a-core
- *          db commit hash: 91e336f10d6789c2e85d9acf48d91e3341c25229
+ * @note  コード生成元 tlm-cmd-db:
+ *          repository:     github.com/arkedge/c2a-core.git
+ *          CSV files MD5:  5da53df42b35605f4b54affc4a518dd7
+ *          db commit hash: 9ed588f4feffa93b4530d7677111ee0ca28247d6
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
@@ -2,9 +2,10 @@
  * @file
  * @brief バッファリングされているテレメをパースしてMOBC内でかんたんに利用できるようにするためのテレメデータ構造体定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 tlm-cmd-db:
- *          repository:     arkedge/c2a-core
- *          db commit hash: 91e336f10d6789c2e85d9acf48d91e3341c25229
+ * @note  コード生成元 tlm-cmd-db:
+ *          repository:     github.com/arkedge/c2a-core.git
+ *          CSV files MD5:  5da53df42b35605f4b54affc4a518dd7
+ *          db commit hash: 9ed588f4feffa93b4530d7677111ee0ca28247d6
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
@@ -2,9 +2,10 @@
  * @file
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 tlm-cmd-db:
- *          repository:     arkedge/c2a-core
- *          db commit hash: 91e336f10d6789c2e85d9acf48d91e3341c25229
+ * @note  コード生成元 tlm-cmd-db:
+ *          repository:     github.com/arkedge/c2a-core.git
+ *          CSV files MD5:  5da53df42b35605f4b54affc4a518dd7
+ *          db commit hash: 9ed588f4feffa93b4530d7677111ee0ca28247d6
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -2,9 +2,9 @@
  * @file
  * @brief ブロックコマンド定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 tlm-cmd-db:
- *          repository:    arkedge/c2a-core
- *          db hash (MD5): da0eb83c38c00e04242184cdd6d225c6
+ * @note  コード生成元 tlm-cmd-db:
+ *          repository:    github.com/arkedge/c2a-core.git
+ *          CSV files MD5: 5da53df42b35605f4b54affc4a518dd7
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
@@ -3,9 +3,9 @@
  * @file
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 tlm-cmd-db:
- *          repository:    arkedge/c2a-core
- *          db hash (MD5): da0eb83c38c00e04242184cdd6d225c6
+ * @note  コード生成元 tlm-cmd-db:
+ *          repository:    github.com/arkedge/c2a-core.git
+ *          CSV files MD5: 5da53df42b35605f4b54affc4a518dd7
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
@@ -2,9 +2,9 @@
  * @file
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 tlm-cmd-db:
- *          repository:    arkedge/c2a-core
- *          db hash (MD5): da0eb83c38c00e04242184cdd6d225c6
+ * @note  コード生成元 tlm-cmd-db:
+ *          repository:    github.com/arkedge/c2a-core.git
+ *          CSV files MD5: 5da53df42b35605f4b54affc4a518dd7
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -3,9 +3,9 @@
  * @file
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 tlm-cmd-db:
- *          repository:    arkedge/c2a-core
- *          db hash (MD5): da0eb83c38c00e04242184cdd6d225c6
+ * @note  コード生成元 tlm-cmd-db:
+ *          repository:    github.com/arkedge/c2a-core.git
+ *          CSV files MD5: 5da53df42b35605f4b54affc4a518dd7
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -2,9 +2,9 @@
  * @file
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 tlm-cmd-db:
- *          repository:    arkedge/c2a-core
- *          db hash (MD5): da0eb83c38c00e04242184cdd6d225c6
+ * @note  コード生成元 tlm-cmd-db:
+ *          repository:    github.com/arkedge/c2a-core.git
+ *          CSV files MD5: 5da53df42b35605f4b54affc4a518dd7
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -2,9 +2,9 @@
  * @file
  * @brief ブロックコマンド定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 tlm-cmd-db:
- *          repository:    arkedge/c2a-core
- *          db hash (MD5): a68cdf10ca467fd750b1d988780fcb5b
+ * @note  コード生成元 tlm-cmd-db:
+ *          repository:    github.com/arkedge/c2a-core.git
+ *          CSV files MD5: 7bd311e714ca9b903ba0bfe4bb4538ea
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
@@ -3,9 +3,9 @@
  * @file
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 tlm-cmd-db:
- *          repository:    arkedge/c2a-core
- *          db hash (MD5): a68cdf10ca467fd750b1d988780fcb5b
+ * @note  コード生成元 tlm-cmd-db:
+ *          repository:    github.com/arkedge/c2a-core.git
+ *          CSV files MD5: 7bd311e714ca9b903ba0bfe4bb4538ea
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
@@ -2,9 +2,9 @@
  * @file
  * @brief コマンド定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 tlm-cmd-db:
- *          repository:    arkedge/c2a-core
- *          db hash (MD5): a68cdf10ca467fd750b1d988780fcb5b
+ * @note  コード生成元 tlm-cmd-db:
+ *          repository:    github.com/arkedge/c2a-core.git
+ *          CSV files MD5: 7bd311e714ca9b903ba0bfe4bb4538ea
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -3,9 +3,9 @@
  * @file
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 tlm-cmd-db:
- *          repository:    arkedge/c2a-core
- *          db hash (MD5): a68cdf10ca467fd750b1d988780fcb5b
+ * @note  コード生成元 tlm-cmd-db:
+ *          repository:    github.com/arkedge/c2a-core.git
+ *          CSV files MD5: 7bd311e714ca9b903ba0bfe4bb4538ea
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -2,9 +2,9 @@
  * @file
  * @brief テレメトリ定義
  * @note  このコードは自動生成されています！
- * @note  コード生成 tlm-cmd-db:
- *          repository:    arkedge/c2a-core
- *          db hash (MD5): a68cdf10ca467fd750b1d988780fcb5b
+ * @note  コード生成元 tlm-cmd-db:
+ *          repository:    github.com/arkedge/c2a-core.git
+ *          CSV files MD5: 7bd311e714ca9b903ba0bfe4bb4538ea
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]


### PR DESCRIPTION
## 概要
#240 で追加された挙動の修正・warning の追加など

## Issue
- 関連する issue

## 詳細
- git コマンドを叩く際，エラーメッセージを生成コードに含めるべきではない
- commit hash が取得できなかった時には曖昧にゼロ埋めすべきでない（この生成コードを機械的に処理するわけではないし，fallback 出力であることを明示すべき）
- git remote は github.com だけではない
- MD5 の計算における改行コードの統一は CRLF ではなく LF にしたい（Linux 文化圏に寄せるため）
  - 「ファイル一覧をソートして各ファイルの MD5 の一覧の MD5 を取ったもの」と言って空で書けるシェルスクリプトと同じ出力にしたい
- code generation check CI での subobc のスキップが雑すぎる上に分かりにくい
  - 一旦は sed でやっていたことを jq でやるように

## 検証結果
test へのリンクや，検証結果へのリンク

## 影響範囲
c2a-code-generator