### PR TITLE
[code-generator] MOBC が定義を持っていない Sub OBC の tlm id の tlm でも GS に Forward できるように

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Enhancements
 - [#240](https://github.com/arkedge/c2a-core/pull/240): code-generator の出力コードに，設定情報を残すようにする
 - [#243](https://github.com/arkedge/c2a-core/pull/243): code-generator に max_tlm_num のアサーションを追加
+- [#256](https://github.com/arkedge/c2a-core/pull/256): code-generator: MOBC が定義を持っていない Sub OBC の tlm でも GS に Forward できるようにする
 
 ### Breaking Changes
 
@@ -30,6 +31,8 @@
     - tlm: `MEM`
   - 設定ファイルを格納する．
     - `examples/mobc/src/src_user/settings/applications/memory_dump_define.h` を参考に．
+- [#256](https://github.com/arkedge/c2a-core/pull/256): user 側でのコードレベルでの対応は不要
+  - 新しい code-generator で生成したコードは，既存のものと diff が発生するため，改めてコード生成し直すとよい．
 
 
 ## v4.1.0 (2023-12-11)

--- a/code-generator/my_mod/tlm_buffer.py
+++ b/code-generator/my_mod/tlm_buffer.py
@@ -175,8 +175,25 @@ def GenerateTlmBuffer(settings, other_obc_dbs):
                 + ");\n"
             )
         body_c += "  default:\n"
-        body_c += "    " + settings["other_obc_data"][i]["code_when_tlm_not_found"] + "\n"
+        body_c += "    // DO NOTHING\n"
+        body_c += "    break;\n"
+        body_c += "  }}\n"
+        body_c += "\n"
+        body_c += "  " + settings["other_obc_data"][i]["code_when_tlm_not_found"] + "\n"
+        body_c += "\n"
+        body_c += "  if (tlm_id >= {_obc_name_upper}_MAX_TLM_NUM)\n"
+        body_c += "  {{\n"
         body_c += "    return CDS_ERR_CODE_ERR;\n"
+        body_c += "  }}\n"
+        body_c += "  else\n"
+        body_c += "  {{\n"
+        body_c += "    // MOBC 側に定義がない tlm でも， GS まで届けられるようにバッファリングはする\n"
+        body_c += (
+            "    {_obc_name_upper}_copy_packet_to_tlm_buffer_(&{_obc_name_upper}_ctp_, tlm_id, "
+            + driver_name
+            + ");\n"
+        )
+        body_c += "    return CDS_ERR_CODE_OK;\n"
         body_c += "  }}\n"
         body_c += "}}\n"
         body_c += "\n"

--- a/code-generator/my_mod/tlm_buffer.py
+++ b/code-generator/my_mod/tlm_buffer.py
@@ -27,6 +27,13 @@ def GenerateTlmBuffer(settings, other_obc_dbs):
         body_h = ""
         tlmdef_body_h = ""
 
+        body_c += (
+            "static void {_obc_name_upper}_copy_packet_to_tlm_buffer_(const CommonTlmPacket* packet, {_obc_name_upper}_TLM_CODE tlm_id, "
+            + driver_type
+            + "* "
+            + driver_name
+            + ");\n"
+        )
         for tlm in tlm_db:
             tlm_name = tlm["tlm_name"]
             tlm_name_lower = tlm_name.lower()
@@ -173,6 +180,20 @@ def GenerateTlmBuffer(settings, other_obc_dbs):
         body_c += "  }}\n"
         body_c += "}}\n"
         body_c += "\n"
+        body_c += (
+            "static void {_obc_name_upper}_copy_packet_to_tlm_buffer_(const CommonTlmPacket* packet, {_obc_name_upper}_TLM_CODE tlm_id, "
+            + driver_type
+            + "* "
+            + driver_name
+            + ")\n"
+        )
+        body_c += "{{\n"
+        body_c += (
+            "  CTP_copy_packet(&(" + driver_name + "->tlm_buffer.tlm[tlm_id].packet), packet);\n"
+        )
+        body_c += "  " + driver_name + "->tlm_buffer.tlm[tlm_id].is_null_packet = 0;\n"
+        body_c += "}}\n"
+        body_c += "\n"
         for tlm in tlm_db:
             conv_tpye_to_temp = {
                 "int8_t": "temp_i8",
@@ -219,12 +240,10 @@ def GenerateTlmBuffer(settings, other_obc_dbs):
             body_c += "\n"
             body_c += "  // GS へのテレメ中継のためのバッファーへのコピー\n"
             body_c += (
-                "  CTP_copy_packet(&("
+                "  {_obc_name_upper}_copy_packet_to_tlm_buffer_(packet, tlm_id, "
                 + driver_name
-                + "->tlm_buffer.tlm[tlm_id].packet), packet);\n"
+                + ");\n"
             )
-            body_c += "  " + driver_name + "->tlm_buffer.tlm[tlm_id].is_null_packet = 0;\n"
-            body_c += "  // TODO: CRC チェック\n"
             body_c += "\n"
 
             body_c += "  // MOBC 内部でテレメデータへアクセスしやすいようにするための構造体へのパース\n"

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
@@ -5,7 +5,7 @@
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
  *          CSV files MD5:  5da53df42b35605f4b54affc4a518dd7
- *          db commit hash: 6cbced9c99c405d7773b3554e3bd0d903707d01a
+ *          db commit hash: bc0d4a0da979ce3f530f155b119ae17bc83f156d
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
@@ -5,7 +5,7 @@
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
  *          CSV files MD5:  5da53df42b35605f4b54affc4a518dd7
- *          db commit hash: 9ed588f4feffa93b4530d7677111ee0ca28247d6
+ *          db commit hash: 6cbced9c99c405d7773b3554e3bd0d903707d01a
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
@@ -6,7 +6,7 @@
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
  *          CSV files MD5:  5da53df42b35605f4b54affc4a518dd7
- *          db commit hash: 9ed588f4feffa93b4530d7677111ee0ca28247d6
+ *          db commit hash: 6cbced9c99c405d7773b3554e3bd0d903707d01a
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC
@@ -25,6 +25,7 @@
 #include "./aobc.h"
 #include <string.h>
 
+static void AOBC_copy_packet_to_tlm_buffer_(const CommonTlmPacket* packet, AOBC_TLM_CODE tlm_id, AOBC_Driver* aobc_driver);
 static CDS_ERR_CODE AOBC_analyze_tlm_aobc_aobc_(const CommonTlmPacket* packet, AOBC_TLM_CODE tlm_id, AOBC_Driver* aobc_driver);
 static CDS_ERR_CODE AOBC_analyze_tlm_aobc_hk_(const CommonTlmPacket* packet, AOBC_TLM_CODE tlm_id, AOBC_Driver* aobc_driver);
 
@@ -62,6 +63,12 @@ CDS_ERR_CODE AOBC_buffer_tlm_packet(CDS_StreamConfig* p_stream_config, AOBC_Driv
   }
 }
 
+static void AOBC_copy_packet_to_tlm_buffer_(const CommonTlmPacket* packet, AOBC_TLM_CODE tlm_id, AOBC_Driver* aobc_driver)
+{
+  CTP_copy_packet(&(aobc_driver->tlm_buffer.tlm[tlm_id].packet), packet);
+  aobc_driver->tlm_buffer.tlm[tlm_id].is_null_packet = 0;
+}
+
 static CDS_ERR_CODE AOBC_analyze_tlm_aobc_aobc_(const CommonTlmPacket* packet, AOBC_TLM_CODE tlm_id, AOBC_Driver* aobc_driver)
 {
   const uint8_t* f = packet->packet;
@@ -75,9 +82,7 @@ static CDS_ERR_CODE AOBC_analyze_tlm_aobc_aobc_(const CommonTlmPacket* packet, A
   double temp_d = 0.0;
 
   // GS へのテレメ中継のためのバッファーへのコピー
-  CTP_copy_packet(&(aobc_driver->tlm_buffer.tlm[tlm_id].packet), packet);
-  aobc_driver->tlm_buffer.tlm[tlm_id].is_null_packet = 0;
-  // TODO: CRC チェック
+  AOBC_copy_packet_to_tlm_buffer_(packet, tlm_id, aobc_driver);
 
   // MOBC 内部でテレメデータへアクセスしやすいようにするための構造体へのパース
   ENDIAN_memcpy(&temp_u16, &(f[0]), 2);
@@ -223,9 +228,7 @@ static CDS_ERR_CODE AOBC_analyze_tlm_aobc_hk_(const CommonTlmPacket* packet, AOB
   double temp_d = 0.0;
 
   // GS へのテレメ中継のためのバッファーへのコピー
-  CTP_copy_packet(&(aobc_driver->tlm_buffer.tlm[tlm_id].packet), packet);
-  aobc_driver->tlm_buffer.tlm[tlm_id].is_null_packet = 0;
-  // TODO: CRC チェック
+  AOBC_copy_packet_to_tlm_buffer_(packet, tlm_id, aobc_driver);
 
   // MOBC 内部でテレメデータへアクセスしやすいようにするための構造体へのパース
   ENDIAN_memcpy(&temp_u16, &(f[0]), 2);

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
@@ -6,7 +6,7 @@
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
  *          CSV files MD5:  5da53df42b35605f4b54affc4a518dd7
- *          db commit hash: 6cbced9c99c405d7773b3554e3bd0d903707d01a
+ *          db commit hash: bc0d4a0da979ce3f530f155b119ae17bc83f156d
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC
@@ -58,8 +58,21 @@ CDS_ERR_CODE AOBC_buffer_tlm_packet(CDS_StreamConfig* p_stream_config, AOBC_Driv
   case AOBC_Tlm_CODE_AOBC_HK:
     return AOBC_analyze_tlm_aobc_hk_(&AOBC_ctp_, tlm_id, aobc_driver);
   default:
-    aobc_driver->info.comm.rx_err_code = AOBC_RX_ERR_CODE_TLM_NOT_FOUND;
+    // DO NOTHING
+    break;
+  }
+
+  aobc_driver->info.comm.rx_err_code = AOBC_RX_ERR_CODE_TLM_NOT_FOUND;
+
+  if (tlm_id >= AOBC_MAX_TLM_NUM)
+  {
     return CDS_ERR_CODE_ERR;
+  }
+  else
+  {
+    // MOBC 側に定義がない tlm でも， GS まで届けられるようにバッファリングはする
+    AOBC_copy_packet_to_tlm_buffer_(&AOBC_ctp_, tlm_id, aobc_driver);
+    return CDS_ERR_CODE_OK;
   }
 }
 

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
@@ -5,7 +5,7 @@
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
  *          CSV files MD5:  5da53df42b35605f4b54affc4a518dd7
- *          db commit hash: 6cbced9c99c405d7773b3554e3bd0d903707d01a
+ *          db commit hash: bc0d4a0da979ce3f530f155b119ae17bc83f156d
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
@@ -5,7 +5,7 @@
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
  *          CSV files MD5:  5da53df42b35605f4b54affc4a518dd7
- *          db commit hash: 9ed588f4feffa93b4530d7677111ee0ca28247d6
+ *          db commit hash: 6cbced9c99c405d7773b3554e3bd0d903707d01a
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
@@ -5,7 +5,7 @@
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
  *          CSV files MD5:  5da53df42b35605f4b54affc4a518dd7
- *          db commit hash: 6cbced9c99c405d7773b3554e3bd0d903707d01a
+ *          db commit hash: bc0d4a0da979ce3f530f155b119ae17bc83f156d
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
@@ -5,7 +5,7 @@
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
  *          CSV files MD5:  5da53df42b35605f4b54affc4a518dd7
- *          db commit hash: 9ed588f4feffa93b4530d7677111ee0ca28247d6
+ *          db commit hash: 6cbced9c99c405d7773b3554e3bd0d903707d01a
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
@@ -5,7 +5,7 @@
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
  *          CSV files MD5:  5da53df42b35605f4b54affc4a518dd7
- *          db commit hash: 6cbced9c99c405d7773b3554e3bd0d903707d01a
+ *          db commit hash: bc0d4a0da979ce3f530f155b119ae17bc83f156d
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
@@ -5,7 +5,7 @@
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
  *          CSV files MD5:  5da53df42b35605f4b54affc4a518dd7
- *          db commit hash: 9ed588f4feffa93b4530d7677111ee0ca28247d6
+ *          db commit hash: 6cbced9c99c405d7773b3554e3bd0d903707d01a
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC


### PR DESCRIPTION
## 概要
sub OBC 側の tlm cmd db を更新したとき，MOBC の FSWを書き換えずとも，GS への forward はできるようにする
もちろん telemetry_data_definitions は更新されないので，直接 MOBC 側からはその tlm を利用することは（MOBC 側の FSW を書き換えずしては）できない．

## 検証結果
CI が通ればOK
