### PR TITLE
C2A 初期化時に実行環境のエンディアンが設定と正しいかチェックする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#268](https://github.com/arkedge/c2a-core/pull/268): GS と FSW 側での同期のために，BCT, TL のダイジェスト (CRC) を下ろせるようにする App の追加
 - [#237](https://github.com/arkedge/c2a-core/pull/237): 任意の Component Driver に対して，任意バイト列の送受信と HAL init, reopen Cmd を提供する
 - [#274](https://github.com/arkedge/c2a-core/pull/274): `TMGR_get_master_mode_cycle_in_msec` などの in_sec 版を実装
+- [#260](https://github.com/arkedge/c2a-core/pull/260): C2A 初期化時に実行環境のエンディアンが設定と正しいかチェックする
 
 ### Breaking Changes
 

--- a/c2a_core_main.c
+++ b/c2a_core_main.c
@@ -3,6 +3,7 @@
 
 #include "./library/git_revision.h"
 #include "./library/print.h"
+#include "./library/endian.h"
 #include "./system/task_manager/task_dispatcher.h"
 #include "./system/application_manager/app_manager.h"
 #include "./system/event_manager/event_manager.h"
@@ -15,6 +16,7 @@
 #include "./tlm_cmd/telemetry_frame.h"
 
 #include <src_user/applications/app_registry.h>
+#include <src_user/settings/build_settings.h>
 
 // git revisionをコードに埋め込む
 const char GIT_REV_CORE[41]         = GIT_REVISION_C2A_CORE;
@@ -24,6 +26,20 @@ const uint32_t GIT_REV_USER_SHORT   = GIT_REVISION_C2A_USER_SHORT;
 
 void C2A_core_init(void)
 {
+  // エンディアンの設定が正しいかの確認
+#ifdef IS_LITTLE_ENDIAN
+  if (ENDIAN_detect_system_endian() != ENDIAN_TYPE_LITTLE)
+  {
+    Printf("WARNING: ENDIAN MISMATCH BETWEEN BUILD SETTINGS AND RUNTIME!\n");
+  }
+#else
+  if (ENDIAN_detect_system_endian() != ENDIAN_TYPE_BIG)
+  {
+    Printf("WARNING: ENDIAN MISMATCH BETWEEN BUILD SETTINGS AND RUNTIME!\n");
+  }
+#endif
+
+  // C2A の初期化
   CA_initialize();            // Cmd Analyze
   Printf("C2A_init: CA_initialize done.\n");
   TF_initialize();            // TLM frame

--- a/c2a_core_main.c
+++ b/c2a_core_main.c
@@ -29,15 +29,16 @@ void C2A_core_init(void)
   // エンディアンの設定が正しいかの確認
 #ifdef IS_LITTLE_ENDIAN
   if (ENDIAN_detect_system_endian() != ENDIAN_TYPE_LITTLE)
-  {
-    Printf("WARNING: ENDIAN MISMATCH BETWEEN BUILD SETTINGS AND RUNTIME!\n");
-  }
 #else
   if (ENDIAN_detect_system_endian() != ENDIAN_TYPE_BIG)
+#endif
   {
     Printf("WARNING: ENDIAN MISMATCH BETWEEN BUILD SETTINGS AND RUNTIME!\n");
   }
-#endif
+  else
+  {
+    Printf("C2A_init: Endian OK.\n");
+  }
 
   // C2A の初期化
   CA_initialize();            // Cmd Analyze

--- a/library/endian.c
+++ b/library/endian.c
@@ -37,4 +37,23 @@ void ENDIAN_conv(void* after, const void* before, size_t size)
   return;
 }
 
+ENDIAN_TYPE ENDIAN_detect_system_endian(void)
+{
+  uint32_t test = 0x12345678;
+  uint8_t* p = (uint8_t*)&test;
+
+  if (*p == 0x12)
+  {
+    return ENDIAN_TYPE_BIG;
+  }
+  else if (*p == 0x78)
+  {
+    return ENDIAN_TYPE_LITTLE;
+  }
+  else
+  {
+    return ENDIAN_TYPE_UNKNOWN;
+  }
+}
+
 #pragma section

--- a/library/endian.h
+++ b/library/endian.h
@@ -40,4 +40,11 @@ void* ENDIAN_memcpy(void* dest, const void* src, size_t size);
  */
 void ENDIAN_conv(void* after, const void* before, size_t size);
 
+/**
+ * @brief  システムのエンディアンを判定する
+ * @param  void
+ * @return ENDIAN_TYPE
+ */
+ENDIAN_TYPE ENDIAN_detect_system_endian(void);
+
 #endif

--- a/library/endian.h
+++ b/library/endian.h
@@ -41,7 +41,7 @@ void* ENDIAN_memcpy(void* dest, const void* src, size_t size);
 void ENDIAN_conv(void* after, const void* before, size_t size);
 
 /**
- * @brief  システムのエンディアンを判定する
+ * @brief  実行環境のエンディアンを判定する
  * @param  void
  * @return ENDIAN_TYPE
  */


### PR DESCRIPTION
## 概要
C2A 初期化時に実行環境のエンディアンが設定と正しいかチェックする．
初期化中なので，警告は出すが，処理は止めない．

これによって，C2A移植時のミスが減る（このミスによるつまずきが多々ある）

## Issue
- https://github.com/arkedge/c2a-core/issues/64

## 検証結果
build and exec CI が通ればOK

![image](https://github.com/arkedge/c2a-core/assets/39541984/5a2958f7-e19b-413c-8eaf-eb8a2347d528)
