### PR TITLE
[code-generator] subobc の MD5 の計算のバグ修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#246](https://github.com/arkedge/c2a-core/pull/246): `node_modules` を `.gitignore` に追加
 - [#249](https://github.com/arkedge/c2a-core/pull/249): `.nvmrc` の追加
 - [#261](https://github.com/arkedge/c2a-core/pull/261): TL TLM に TL に登録された cmd 数を追加
+- [#265](https://github.com/arkedge/c2a-core/pull/265): code-generator: subobc の MD5 の計算のバグ修正
 
 ### Documentation
 
@@ -36,6 +37,8 @@
   - 新しい code-generator で生成したコードは，既存のものと diff が発生するため，改めてコード生成し直すとよい．
 - [#261](https://github.com/arkedge/c2a-core/pull/261): user 側でのコードレベルでの対応は不要
   - `examples/mobc` の TL TLM を更新したので， `examples/mobc/tlm-cmd-db/TLM_DB/SAMPLE_MOBC_TLM_DB_TL.csv` を user 側の TL TLM に上書きし， tlm db を再度読み込み，再出力することで更新し，そのあとコード生成し直すとよい．
+- [#265](https://github.com/arkedge/c2a-core/pull/265): user 側でのコードレベルでの対応は不要
+  - 新しい code-generator で生成したコードは，既存のものと diff が発生するため，改めてコード生成し直すとよい．
 
 
 ## v4.1.0 (2023-12-11)

--- a/code-generator/my_mod/util.py
+++ b/code-generator/my_mod/util.py
@@ -36,7 +36,7 @@ def GenerateSubObcSettingNote(settings, obc_idx):
     note += " * @note  コード生成元 tlm-cmd-db:\n"
     note += " *          repository:     "
     note += GetRepo_(sub_obc_settings["path_to_db"]) + "\n"
-    note += " *          CSV files MD5:  " + GetDbHash_(settings["path_to_db"]) + "\n"
+    note += " *          CSV files MD5:  " + GetDbHash_(sub_obc_settings["path_to_db"]) + "\n"
     note += " *          db commit hash: " + GetCommitHash_(sub_obc_settings["path_to_db"]) + "\n"
     note += " * @note  コード生成パラメータ:\n"
     note += " *          name:                    " + sub_obc_settings["name"] + "\n"

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
@@ -4,8 +4,8 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
- *          CSV files MD5:  fab1e97975ab6bc4824720ff3cc8d498
- *          db commit hash: 588dd2c10543d78c1ea39ca6b7cac11de2ffb69e
+ *          CSV files MD5:  7bd311e714ca9b903ba0bfe4bb4538ea
+ *          db commit hash: b9b644b2faeb088cd3aec10ed8fb36237e934e04
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
@@ -5,8 +5,8 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
- *          CSV files MD5:  fab1e97975ab6bc4824720ff3cc8d498
- *          db commit hash: 588dd2c10543d78c1ea39ca6b7cac11de2ffb69e
+ *          CSV files MD5:  7bd311e714ca9b903ba0bfe4bb4538ea
+ *          db commit hash: b9b644b2faeb088cd3aec10ed8fb36237e934e04
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
@@ -4,8 +4,8 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
- *          CSV files MD5:  fab1e97975ab6bc4824720ff3cc8d498
- *          db commit hash: 588dd2c10543d78c1ea39ca6b7cac11de2ffb69e
+ *          CSV files MD5:  7bd311e714ca9b903ba0bfe4bb4538ea
+ *          db commit hash: b9b644b2faeb088cd3aec10ed8fb36237e934e04
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
@@ -4,8 +4,8 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
- *          CSV files MD5:  fab1e97975ab6bc4824720ff3cc8d498
- *          db commit hash: 588dd2c10543d78c1ea39ca6b7cac11de2ffb69e
+ *          CSV files MD5:  7bd311e714ca9b903ba0bfe4bb4538ea
+ *          db commit hash: b9b644b2faeb088cd3aec10ed8fb36237e934e04
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
@@ -4,8 +4,8 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
- *          CSV files MD5:  fab1e97975ab6bc4824720ff3cc8d498
- *          db commit hash: 588dd2c10543d78c1ea39ca6b7cac11de2ffb69e
+ *          CSV files MD5:  7bd311e714ca9b903ba0bfe4bb4538ea
+ *          db commit hash: b9b644b2faeb088cd3aec10ed8fb36237e934e04
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC


### PR DESCRIPTION
## 概要
- https://github.com/arkedge/c2a-core/pull/251 で追加された，subobc での db hash (md5) の計算が，subobc ではなく，生成対象 OBC の db の md5 を計算していたので，修正


