### PR TITLE
sync_with_mobc_example.bat のメンテ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [#265](https://github.com/arkedge/c2a-core/pull/265): code-generator: subobc の MD5 の計算のバグ修正
 - [#267](https://github.com/arkedge/c2a-core/pull/267): core tlm の tlm id の再採番 (CDIS, CA)
 - [#271](https://github.com/arkedge/c2a-core/pull/271): CDS: ComponentDriverSuper の整理（コードに変更なし）
+- [#272](https://github.com/arkedge/c2a-core/pull/272): `sync_with_mobc_example.bat` のメンテ
 
 ### Documentation
 

--- a/examples/subobc/src/src_user/settings/tlm_cmd/ccsds/apid_define.h
+++ b/examples/subobc/src/src_user/settings/tlm_cmd/ccsds/apid_define.h
@@ -23,7 +23,7 @@ typedef enum
   APID_TLM_MOBC = 0x510,      //!< 10100010000b: APID for MOBC で生成される TLM
   APID_TLM_AOBC = 0x511,      //!< 10100010001b: APID for AOBC で生成される TLM
   APID_TLM_TOBC = 0x512,      //!< 10100010002b: APID for TOBC で生成される TLM
-  APID_TLM_DUMP = 0x710,      //!< 11100010000b: APID for DUMP TLM (FIXME: 現在まともに使ってない)
+  APID_TLM_DUMP = 0x710,      //!< 11100010000b: APID for DUMP TLM
   APID_FILL_PKT = 0x7ff,      //!< 11111111111b: APID for FILL PACKET
   APID_UNKNOWN
 } APID;

--- a/examples/subobc/sync_with_mobc_example.bat
+++ b/examples/subobc/sync_with_mobc_example.bat
@@ -9,7 +9,6 @@ echo.
 call :sync_dir ".\src\s2e_mockup\" "..\mobc\src\s2e_mockup\"
 call :sync_dir ".\src\src_user\library\" "..\mobc\src\src_user\library\"
 call :sync_dir ".\src\src_user\script\" "..\mobc\src\src_user\script\"
-call :sync_dir ".\src\src_user\settings\tlm_cmd\ccsds\" "..\mobc\src\src_user\settings\tlm_cmd\ccsds\"
 
 call :sync_file ".\src\src_user\applications\user_defined\debug_apps.h" "..\mobc\src\src_user\applications\user_defined\debug_apps.h"
 call :sync_file ".\src\src_user\hal\sils\uart_sils_sci_if.hpp" "..\mobc\src\src_user\hal\sils\uart_sils_sci_if.hpp"
@@ -21,13 +20,18 @@ call :sync_file ".\src\src_user\settings\git_revision_config.h" "..\mobc\src\src
 call :sync_file ".\src\src_user\settings\component_driver_super\driver_buffer_define.h" "..\mobc\src\src_user\settings\component_driver_super\driver_buffer_define.h"
 call :sync_file ".\src\src_user\settings\tlm_cmd\common_cmd_packet_define.c" "..\mobc\src\src_user\settings\tlm_cmd\common_cmd_packet_define.c"
 call :sync_file ".\src\src_user\settings\tlm_cmd\common_tlm_cmd_packet_define.h" "..\mobc\src\src_user\settings\tlm_cmd\common_tlm_cmd_packet_define.h"
+call :sync_file ".\src\src_user\settings\tlm_cmd\ccsds\apid_define.c" "..\mobc\src\src_user\settings\tlm_cmd\ccsds\apid_define.c"
+call :sync_file ".\src\src_user\settings\tlm_cmd\ccsds\apid_define.h" "..\mobc\src\src_user\settings\tlm_cmd\ccsds\apid_define.h"
+call :sync_file ".\src\src_user\settings\tlm_cmd\ccsds\cmd_space_packet_params.h" "..\mobc\src\src_user\settings\tlm_cmd\ccsds\cmd_space_packet_params.h"
+call :sync_file ".\src\src_user\settings\tlm_cmd\ccsds\space_packet_typedef_params.h" "..\mobc\src\src_user\settings\tlm_cmd\ccsds\space_packet_typedef_params.h"
+call :sync_file ".\src\src_user\settings\tlm_cmd\ccsds\tlm_space_packet_params.h" "..\mobc\src\src_user\settings\tlm_cmd\ccsds\tlm_space_packet_params.h"
 call :sync_file ".\src\src_user\tlm_cmd\block_command_user_settings.c" "..\mobc\src\src_user\tlm_cmd\block_command_user_settings.c"
 call :sync_file ".\src\src_user\tlm_cmd\block_command_user_settings.h" "..\mobc\src\src_user\tlm_cmd\block_command_user_settings.h"
 call :sync_file ".\src\src_user\tlm_cmd\command_source.h" "..\mobc\src\src_user\tlm_cmd\command_source.h"
 call :sync_file ".\src\src_user\tlm_cmd\common_cmd_packet.c" "..\mobc\src\src_user\tlm_cmd\common_cmd_packet.c"
 call :sync_file ".\src\src_user\tlm_cmd\common_tlm_cmd_packet.c" "..\mobc\src\src_user\tlm_cmd\common_tlm_cmd_packet.c"
 
-call :sync_file ".\src\src_user\Test\utils\wings_utils.py" "..\mobc\src\src_user\Test\utils\wings_utils.py"
+rem call :sync_file ".\src\src_user\Test\utils\wings_utils.py" "..\mobc\src\src_user\Test\utils\wings_utils.py"
 call :sync_file ".\src\src_user\Test\pytest.ini" "..\mobc\src\src_user\Test\pytest.ini"
 
 


### PR DESCRIPTION
## 概要
example mobc / subobc で全く同じコードを同期するスクリプトが古くなっていたのでメンテ

## 補足
- [x] https://github.com/arkedge/c2a-core/pull/270 を先にマージする