### PR TITLE
`TMGR_get_master_mode_cycle_in_msec` などの in_sec 版を実装

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#263](https://github.com/arkedge/c2a-core/pull/263): CDIS や BCT に保存された CCP をダンプする App を追加
 - [#268](https://github.com/arkedge/c2a-core/pull/268): GS と FSW 側での同期のために，BCT, TL のダイジェスト (CRC) を下ろせるようにする App の追加
 - [#237](https://github.com/arkedge/c2a-core/pull/237): 任意の Component Driver に対して，任意バイト列の送受信と HAL init, reopen Cmd を提供する
+- [#274](https://github.com/arkedge/c2a-core/pull/274): `TMGR_get_master_mode_cycle_in_msec` などの in_sec 版を実装
 
 ### Breaking Changes
 

--- a/system/time_manager/time_manager.c
+++ b/system/time_manager/time_manager.c
@@ -116,6 +116,16 @@ uint32_t TMGR_get_master_mode_cycle_in_msec(void)
   return OBCT_get_mode_cycle_in_msec(&time_manager_.master_clock_);
 }
 
+double TMGR_get_master_total_cycle_in_sec(void)
+{
+  return OBCT_get_total_cycle_in_sec(&time_manager_.master_clock_);
+}
+
+double TMGR_get_master_mode_cycle_in_sec(void)
+{
+  return OBCT_get_mode_cycle_in_sec(&time_manager_.master_clock_);
+}
+
 static TMGR_ACK TMGR_set_master_total_cycle_(cycle_t total_cycle)
 {
   if (total_cycle >= OBCT_MAX_CYCLE) return TMGR_ACK_PARAM_ERR;

--- a/system/time_manager/time_manager.h
+++ b/system/time_manager/time_manager.h
@@ -139,6 +139,22 @@ uint32_t TMGR_get_master_total_cycle_in_msec(void);
 uint32_t TMGR_get_master_mode_cycle_in_msec(void);
 
 /**
+ * @brief 現在の total_cycle を秒単位で返す
+ * @note 計算上はstepも考慮
+ * @param void
+ * @return 秒単位の total_cycle. 少数点以下も保持
+ */
+double TMGR_get_master_total_cycle_in_sec(void);
+
+/**
+ * @brief 現在の mode_cycle を秒単位で返す
+ * @note 計算上はstepも考慮
+ * @param void
+ * @return 秒単位の mode_cycle. 少数点以下も保持
+ */
+double TMGR_get_master_mode_cycle_in_sec(void);
+
+/**
  * @brief unixtime_info_ を初期化する
  * @param void
  * @return void


### PR DESCRIPTION
## 概要
よりオーバーフローしにくい時刻取得関数を実装

## Issue
- https://github.com/arkedge/c2a-core/issues/108

## 補足
- [x] https://github.com/arkedge/c2a-core/pull/273 を先にマージする
