### PR TITLE
component_driver_utility.c でのパラメタ取得のバグ修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [#271](https://github.com/arkedge/c2a-core/pull/271): CDS: ComponentDriverSuper の整理（コードに変更なし）
 - [#272](https://github.com/arkedge/c2a-core/pull/272): `sync_with_mobc_example.bat` のメンテ
 - [#275](https://github.com/arkedge/c2a-core/pull/275): AM tlm で不用意にサイズを切り詰めたキャストを緩和し，初期化時間や実行時間の長い App の時間を正確に知れるように
+- [#279](https://github.com/arkedge/c2a-core/pull/279): `component_driver_utility.c` でのパラメタ取得のバグ修正
 
 ### Documentation
 

--- a/applications/component_driver_utility.c
+++ b/applications/component_driver_utility.c
@@ -251,7 +251,7 @@ CCP_CmdRet Cmd_CDRV_UTIL_HAL_REOPEN(const CommonCmdPacket* packet)
 {
   ComponentDriverSuper* cds;
   CDRV_ID cdrv_id = (CDRV_ID)CCP_get_param_from_packet(packet, 0, uint8_t);
-  int32_t reason = CCP_get_param_from_packet(packet, 0, int32_t);
+  int32_t reason = CCP_get_param_from_packet(packet, 1, int32_t);
 
   if (cdrv_id >= CDRV_ID_MAX) return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_PARAMETER, 1);
   cds = (ComponentDriverSuper*)CDRV_get_cds(cdrv_id);    // const_cast
@@ -272,8 +272,8 @@ CCP_CmdRet Cmd_CDRV_UTIL_HAL_RX_TO_RAM(const CommonCmdPacket* packet)
 {
   ComponentDriverSuper* cds;
   CDRV_ID cdrv_id = (CDRV_ID)CCP_get_param_from_packet(packet, 0, uint8_t);
-  uint32_t buffer_adr = CCP_get_param_from_packet(packet, 0, uint32_t);
-  int32_t buffer_size = CCP_get_param_from_packet(packet, 0, int32_t);
+  uint32_t buffer_adr = CCP_get_param_from_packet(packet, 1, uint32_t);
+  int32_t buffer_size = CCP_get_param_from_packet(packet, 2, int32_t);
 
   if (cdrv_id >= CDRV_ID_MAX) return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_PARAMETER, 1);
   if (buffer_size <= 0) return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_PARAMETER, 2);
@@ -289,8 +289,8 @@ CCP_CmdRet Cmd_CDRV_UTIL_HAL_TX_FROM_RAM(const CommonCmdPacket* packet)
 {
   ComponentDriverSuper* cds;
   CDRV_ID cdrv_id = (CDRV_ID)CCP_get_param_from_packet(packet, 0, uint8_t);
-  uint32_t data_adr = CCP_get_param_from_packet(packet, 0, uint32_t);
-  int32_t data_size = CCP_get_param_from_packet(packet, 0, int32_t);
+  uint32_t data_adr = CCP_get_param_from_packet(packet, 1, uint32_t);
+  int32_t data_size = CCP_get_param_from_packet(packet, 2, int32_t);
 
   if (cdrv_id >= CDRV_ID_MAX) return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_PARAMETER, 1);
   if (data_size <= 0) return CCP_make_cmd_ret(CCP_EXEC_ILLEGAL_PARAMETER, 2);


### PR DESCRIPTION
## 概要
- https://github.com/arkedge/c2a-core/pull/273 のバグ修正

