### PR TITLE
Use Gaia 0.6 in C2A Boom for C2A DevTools usage update

### DIFF
--- a/docs/development/development_environment.md
+++ b/docs/development/development_environment.md
@@ -18,7 +18,7 @@ nvm は Node.js のインストーラー・バージョンマネージャであ�
 インストール: https://github.com/nvm-sh/nvm#installing-and-updating
 
 ### yarn
-C2A 開発そのものには不要であるが，[c2a-devtools](https://github.com/arkedge/c2a-devtools) の実行に必要である．
+[C2A DevTools](https://github.com/arkedge/gaia/tree/v0.6.1/tmtc-c2a/devtools_frontend) が有効な [Gaia](https://github.com/arkedge/gaia)(tmtc-c2a) のビルド(現状では `npm install` 時に内部で行われる)に必要．
 
 インストール: https://classic.yarnpkg.com/lang/en/docs/install/
 

--- a/docs/development/development_environment.md
+++ b/docs/development/development_environment.md
@@ -18,7 +18,7 @@ nvm は Node.js のインストーラー・バージョンマネージャであ�
 インストール: https://github.com/nvm-sh/nvm#installing-and-updating
 
 ### yarn
-[C2A DevTools](https://github.com/arkedge/gaia/tree/v0.6.1/tmtc-c2a/devtools_frontend) が有効な [Gaia](https://github.com/arkedge/gaia)(tmtc-c2a) のビルド(現状では `npm install` 時に内部で行われる)に必要．
+[C2A DevTools](https://github.com/arkedge/gaia/tree/v0.6.1/tmtc-c2a/devtools_frontend) が有効な [Gaia](https://github.com/arkedge/gaia) (tmtc-c2a) のビルド (現状では `npm install` 時に内部で行われる) に必要．
 
 インストール: https://classic.yarnpkg.com/lang/en/docs/install/
 

--- a/docs/sils/c2a_sils_runtime.md
+++ b/docs/sils/c2a_sils_runtime.md
@@ -30,21 +30,21 @@ cargo run
 ```
 を実行するだけ．
 
-### c2a-devtools の実行
-[c2a-devtools](https://github.com/arkedge/c2a-devtools) によって，c2a-sils-runtime によって実行されている SILS に対して，テレコマ通信が可能である．
+### C2A DevTools の実行
+[C2A DevTools](https://github.com/arkedge/gaia/tree/v0.6.1/tmtc-c2a/devtools_frontend) によって，c2a-sils-runtime によって実行されている SILS に対して，テレコマ通信が可能である．
 使い方の詳細は，上記リンク先を参照のこと．
 
-### C2A そのもの + c2a-devtools の実行
+### C2A そのもの + C2A DevTools の実行
 MOBC 環境 (`/examples/mobc/`) を例にする．
 
 1. 1 つ目のターミナルで `/examples/mobc/` に移動し，次を実行する．
 ```
 npm run devtools:sils
 ```
-2. 2 つ目のターミナルで c2a-devtools を実行し，ブラウザを開くと，テレコマ通信が可能となる．
+2. ブラウザで `http://localhost:8900/devtools/` を開くと，テレコマ通信が可能となる．
 
 
-### C2A そのもの + c2a-devtools の実行 (VS Code を用いたデバッグ)
+### C2A そのもの + C2A DevTools の実行 (VS Code を用いたデバッグ)
 MOBC 環境 (`/examples/mobc/`) を例にする．  
 この手順によって，ブレークポイント等を用いた開発が可能となる．
 
@@ -53,7 +53,7 @@ MOBC 環境 (`/examples/mobc/`) を例にする．
 npm run devtools:debug
 ```
 2. VS Code のデバッガで `Debug executable 'c2a-example-mobc` を実行する．
-3. 2 つ目のターミナルで c2a-devtools を実行し，ブラウザを開くと，テレコマ通信が可能となる．
+3. ブラウザで `http://localhost:8900/devtools/` を開くと，テレコマ通信が可能となる．
 
 
 ### pytest の実行

--- a/examples/mobc/tools/install.sh
+++ b/examples/mobc/tools/install.sh
@@ -2,7 +2,7 @@
 
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
-cargo install --debug --root . tmtc-c2a --git https://github.com/arkedge/gaia.git --tag v0.5.0
+cargo install --debug --root . tmtc-c2a --git https://github.com/arkedge/gaia.git --tag v0.6.1
 
 cargo install --debug --root . tlmcmddb-cli    --version 0.2.0
 cargo install --debug --root . kble            --version 0.2.0

--- a/examples/subobc/tools/install.sh
+++ b/examples/subobc/tools/install.sh
@@ -2,7 +2,7 @@
 
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 
-cargo install --debug --root . tmtc-c2a --git https://github.com/arkedge/gaia.git --tag v0.5.0
+cargo install --debug --root . tmtc-c2a --git https://github.com/arkedge/gaia.git --tag v0.6.1
 
 cargo install --debug --root . tlmcmddb-cli    --version 0.2.0
 cargo install --debug --root . kble            --version 0.2.0


### PR DESCRIPTION
## 概要
[C2A DevTools](https://github.com/arkedge/c2a-devtools) が Gaia に統合されたため，C2A Boom でのバージョンを更新します．

また，これに伴って C2A DevTools のドキュメントを更新します．

## Issue
- https://github.com/arkedge/gaia/issues/30

## 検証結果
`npm install` し直して Gaia に統合された C2A DevTools が使えればよし

## 影響範囲
C2A Boom