### PR TITLE
Fix check-coding-rule v4 workflow in workflows-c2a v5

### DIFF
--- a/.github/workflows/check_coding_rule.yml
+++ b/.github/workflows/check_coding_rule.yml
@@ -15,7 +15,7 @@ jobs:
         user:
           - mobc
           - subobc
-    uses: arkedge/workflows-c2a/.github/workflows/check-coding-rule-v4.yml@v5.0.0
+    uses: arkedge/workflows-c2a/.github/workflows/check-coding-rule.yml@v5.0.0
     with:
       c2a_dir: examples/${{ matrix.user }}
       c2a_custom_setup: |


### PR DESCRIPTION
## 概要
#257 での check-coding-rule workflow の参照の修正

## Issue / PR
- #257 

## 詳細
reusable workflow の参照ミスなので動作していないことに気付くのが遅れました（failed になって後で notification は来るがそもそも走り始めていないので status check は付かない）．#257 をマージする際によく確認すべきでした．

## 検証結果
check-coding-rule workflow が動作すればよし

## 影響範囲
check-coding-rule CI