### PR TITLE
Enable example build all again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
         else
           ./setup.sh
         fi
+      build_msvc: true
+      build_as_cxx: true
 
   subobc:
     name: subobc
@@ -37,3 +39,5 @@ jobs:
         else
           ./setup.sh
         fi
+      build_msvc: true
+      build_as_cxx: true


### PR DESCRIPTION
## 概要
#257 で MSVC, C++ でのビルドが optional になったが，c2a-core は様々な場所で使われるため，これらのビルドを c2a-core として明確にサポート排除するまではビルドをやめない

## Issue / PR
- #257 

## 検証結果
Example user の MSVC, C++ での Build CI が再度走るようになればよし

## 影響範囲
example user Build CI