### PR TITLE
`CCP_form_and_exec_*` の再帰実行時のメモリエラーバグの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,25 @@
 - [CHANGELOG](./CHANGELOG.md)
 
 
+## 必要環境
+### CPU 速度
+TBW
+
+### メモリ
+#### 静的領域
+TBW
+
+#### スタック
+C2A core 内部で，`CommonTlmCmdPacket`，`CommonTlmPacket`，`CommonCmdPacket` （[`communication.md`](/docs/core/communication.md) 参照）などのサイズの大きい変数が確保されることがあるため，これらの構造体を複数個確保できるスタックメモリが必要となる．
+なお，コマンド内部で別のコマンドを実行する際に用いる `CCP_form_and_exec_*` 関数は，実行した別のコマンドで更に他のコマンドを実行するなどすると再帰的に呼ばれるため，再帰回数だけ `CommonCmdPacket` をスタックメモリに確保することになるので，実行時のスタックメモリ枯渇に注意すること．
+
+#### ヒープ
+動的メモリ確保は行わない．
+
+### その他
+TBW
+
+
 ## 開発
 ### セットアップ
 1. clone 後， [`setup.bat`](./setup.bat) or [`setup.sh`](./setup.sh) を実行

--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@
 
 ## 必要環境
 ### CPU 速度
-TBW
+TBW  
+メモリ使用量に大きく関わるパラメタについては [`parameter_settings.md`](docs/tips/parameter_settings.md) を参照のこと．
 
 ### メモリ
 #### 静的領域
-TBW
+TBW．
 
 #### スタック
-C2A core 内部で，`CommonTlmCmdPacket`，`CommonTlmPacket`，`CommonCmdPacket` （[`communication.md`](/docs/core/communication.md) 参照）などのサイズの大きい変数が確保されることがあるため，これらの構造体を複数個確保できるスタックメモリが必要となる．
+C2A core 内部で，`CommonTlmCmdPacket`，`CommonTlmPacket`，`CommonCmdPacket` （[`communication.md`](/docs/core/communication.md) 参照）などのサイズの大きい変数が確保されることがあるため，これらの構造体を複数個確保できるスタックメモリが必要となる．  
 なお，コマンド内部で別のコマンドを実行する際に用いる `CCP_form_and_exec_*` 関数は，実行した別のコマンドで更に他のコマンドを実行するなどすると再帰的に呼ばれるため，再帰回数だけ `CommonCmdPacket` をスタックメモリに確保することになるので，実行時のスタックメモリ枯渇に注意すること．
 
 #### ヒープ

--- a/README.md
+++ b/README.md
@@ -15,27 +15,8 @@
 ## ドキュメント
 - ドキュメント:  https://github.com/arkedge/c2a-core/tree/main/docs
 - リファレンス (TBD):  https://github.com/ut-issl/c2a-reference
+- [Requirements](./docs/general/requirements.md)
 - [CHANGELOG](./CHANGELOG.md)
-
-
-## 必要環境
-### CPU 速度
-TBW  
-メモリ使用量に大きく関わるパラメタについては [`parameter_settings.md`](docs/tips/parameter_settings.md) を参照のこと．
-
-### メモリ
-#### 静的領域
-TBW．
-
-#### スタック
-C2A core 内部で，`CommonTlmCmdPacket`，`CommonTlmPacket`，`CommonCmdPacket` （[`communication.md`](/docs/core/communication.md) 参照）などのサイズの大きい変数が確保されることがあるため，これらの構造体を複数個確保できるスタックメモリが必要となる．  
-なお，コマンド内部で別のコマンドを実行する際に用いる `CCP_form_and_exec_*` 関数は，実行した別のコマンドで更に他のコマンドを実行するなどすると再帰的に呼ばれるため，再帰回数だけ `CommonCmdPacket` をスタックメモリに確保することになるので，実行時のスタックメモリ枯渇に注意すること．
-
-#### ヒープ
-動的メモリ確保は行わない．
-
-### その他
-TBW
 
 
 ## 開発

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ C2A に関する説明の棲み分けは，次のようになっています．
 
 1. General Information
    1. [Overview](./general/overview.md)
+   1. [Requirements](./general/requirements.md)
    1. [Release](./general/release.md)
    1. [Coding Rule](./general/coding_rule.md)
    1. [Coding Acronyms](./general/coding_acronyms.md)

--- a/docs/general/requirements.md
+++ b/docs/general/requirements.md
@@ -1,0 +1,21 @@
+# Requirements
+
+## CPU 速度
+TBW  
+メモリ使用量に大きく関わるパラメタについては [`parameter_settings.md`](docs/tips/parameter_settings.md) を参照のこと．
+
+## メモリ
+### 静的領域
+TBW．
+
+### スタック
+C2A core 内部で，`CommonTlmCmdPacket`，`CommonTlmPacket`，`CommonCmdPacket` （[`communication.md`](/docs/core/communication.md) 参照）などのサイズの大きい変数が確保されることがあるため，これらの構造体を複数個確保できるスタックメモリが必要となる．  
+なお，コマンド内部で別のコマンドを実行する際に用いる `CCP_form_and_exec_*` 関数は，実行した別のコマンドで更に他のコマンドを実行するなどすると再帰的に呼ばれるため，再帰回数だけ `CommonCmdPacket` をスタックメモリに確保することになるので，実行時のスタックメモリ枯渇に注意すること．
+
+議論: https://github.com/arkedge/c2a-core/issues/303
+
+### ヒープ
+動的メモリ確保は行わない．
+
+## その他
+TBW

--- a/docs/general/requirements.md
+++ b/docs/general/requirements.md
@@ -10,7 +10,7 @@ TBW
 メモリ使用量に大きく関わるパラメタについては [`parameter_settings.md`](../tips/parameter_settings.md) を参照のこと．
 
 ### スタック
-C2A core 内部で，`CommonTlmCmdPacket`，`CommonTlmPacket`，`CommonCmdPacket` （[`communication.md`](/docs/core/communication.md) 参照）などのサイズの大きい変数が確保されることがあるため，これらの構造体を複数個確保できるスタックメモリが必要となる．  
+C2A core 内部で，`CommonTlmCmdPacket`，`CommonTlmPacket`，`CommonCmdPacket` （[`communication.md`](../core/communication.md) 参照）などのサイズの大きい変数が確保されることがあるため，これらの構造体を複数個確保できるスタックメモリが必要となる．  
 なお，コマンド内部で別のコマンドを実行する際に用いる `CCP_form_and_exec_*` 関数は，実行した別のコマンドで更に他のコマンドを実行するなどすると再帰的に呼ばれるため，再帰回数だけ `CommonCmdPacket` をスタックメモリに確保することになるので，実行時のスタックメモリ枯渇に注意すること．
 
 議論: https://github.com/arkedge/c2a-core/issues/303

--- a/docs/general/requirements.md
+++ b/docs/general/requirements.md
@@ -1,12 +1,13 @@
 # Requirements
 
 ## CPU 速度
-TBW  
-メモリ使用量に大きく関わるパラメタについては [`parameter_settings.md`](docs/tips/parameter_settings.md) を参照のこと．
+TBW
+
 
 ## メモリ
 ### 静的領域
-TBW．
+TBW  
+メモリ使用量に大きく関わるパラメタについては [`parameter_settings.md`](../tips/parameter_settings.md) を参照のこと．
 
 ### スタック
 C2A core 内部で，`CommonTlmCmdPacket`，`CommonTlmPacket`，`CommonCmdPacket` （[`communication.md`](/docs/core/communication.md) 参照）などのサイズの大きい変数が確保されることがあるため，これらの構造体を複数個確保できるスタックメモリが必要となる．  
@@ -16,6 +17,7 @@ C2A core 内部で，`CommonTlmCmdPacket`，`CommonTlmPacket`，`CommonCmdPacket
 
 ### ヒープ
 動的メモリ確保は行わない．
+
 
 ## その他
 TBW

--- a/tlm_cmd/common_cmd_packet_util.c
+++ b/tlm_cmd/common_cmd_packet_util.c
@@ -22,7 +22,6 @@ typedef struct
   CMD_CODE cmd_id;          //!< どのコマンドの param か
 } CCP_ParamGenerator;
 
-static CommonCmdPacket CCP_util_packet_;
 static CCP_ParamGenerator CCP_param_generator_;
 
 
@@ -253,17 +252,19 @@ void CCP_convert_rtc_to_tlc(CommonCmdPacket* packet, cycle_t ti)
 
 PH_ACK CCP_register_rtc(CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
-  if (CCP_form_rtc(&CCP_util_packet_, cmd_id, param, len) != CCP_UTIL_ACK_OK)
+  CommonCmdPacket ccp;
+  if (CCP_form_rtc(&ccp, cmd_id, param, len) != CCP_UTIL_ACK_OK)
   {
     return PH_ACK_INVALID_PACKET;
   }
 
-  return PH_analyze_cmd_packet(&CCP_util_packet_);
+  return PH_analyze_cmd_packet(&ccp);
 }
 
 
 PH_ACK CCP_register_tlc(cycle_t ti, TLCD_ID tlcd_id, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
+  CommonCmdPacket ccp;
   CCP_EXEC_TYPE type = CCP_get_exec_type_from_tlcd_id(tlcd_id);
 
   if (type == CCP_EXEC_TYPE_UNKNOWN)
@@ -271,18 +272,19 @@ PH_ACK CCP_register_tlc(cycle_t ti, TLCD_ID tlcd_id, CMD_CODE cmd_id, const uint
     return PH_ACK_INVALID_PACKET;
   }
 
-  if (CCP_form_tlc(&CCP_util_packet_, ti, cmd_id, param, len) != CCP_UTIL_ACK_OK)
+  if (CCP_form_tlc(&ccp, ti, cmd_id, param, len) != CCP_UTIL_ACK_OK)
   {
     return PH_ACK_INVALID_PACKET;
   }
 
-  CCP_set_exec_type(&CCP_util_packet_, type);
-  return PH_analyze_cmd_packet(&CCP_util_packet_);
+  CCP_set_exec_type(&ccp, type);
+  return PH_analyze_cmd_packet(&ccp);
 }
 
 
 PH_ACK CCP_register_tlc_asap(cycle_t ti, TLCD_ID tlcd_id, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
+  CommonCmdPacket ccp;
   CCP_EXEC_TYPE type = CCP_get_exec_type_from_tlcd_id(tlcd_id);
   const PacketList* pl = PH_get_packet_list_from_exec_type(type);
 
@@ -324,48 +326,51 @@ PH_ACK CCP_register_tlc_asap(cycle_t ti, TLCD_ID tlcd_id, CMD_CODE cmd_id, const
     }
   }
 
-  if (CCP_form_tlc(&CCP_util_packet_, ti, cmd_id, param, len) != CCP_UTIL_ACK_OK)
+  if (CCP_form_tlc(&ccp, ti, cmd_id, param, len) != CCP_UTIL_ACK_OK)
   {
     return PH_ACK_INVALID_PACKET;
   }
-  CCP_set_exec_type(&CCP_util_packet_, type);
-  return PH_analyze_cmd_packet(&CCP_util_packet_);
+  CCP_set_exec_type(&ccp, type);
+  return PH_analyze_cmd_packet(&ccp);
 }
 
 
 CCP_CmdRet CCP_form_and_exec_rtc(CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
-  CCP_UTIL_ACK ret = CCP_form_rtc(&CCP_util_packet_, cmd_id, param, len);
+  CommonCmdPacket ccp;
+  CCP_UTIL_ACK ret = CCP_form_rtc(&ccp, cmd_id, param, len);
   if (ret != CCP_UTIL_ACK_OK)
   {
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_PACKET_FMT_ERR);
   }
 
-  return PH_dispatch_command(&CCP_util_packet_);
+  return PH_dispatch_command(&ccp);
 }
 
 
 CCP_CmdRet CCP_form_and_exec_rtc_to_other_obc(APID apid, CMD_CODE cmd_id, const uint8_t* param, uint16_t len)
 {
-  CCP_UTIL_ACK ret = CCP_form_rtc_to_other_obc(&CCP_util_packet_, apid, cmd_id, param, len);
+  CommonCmdPacket ccp;
+  CCP_UTIL_ACK ret = CCP_form_rtc_to_other_obc(&ccp, apid, cmd_id, param, len);
   if (ret != CCP_UTIL_ACK_OK)
   {
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_PACKET_FMT_ERR);
   }
 
-  return PH_dispatch_command(&CCP_util_packet_);
+  return PH_dispatch_command(&ccp);
 }
 
 
 CCP_CmdRet CCP_form_and_exec_block_deploy_cmd(TLCD_ID tl_no, bct_id_t block_no)
 {
-  CCP_UTIL_ACK ret = CCP_form_block_deploy_cmd(&CCP_util_packet_, tl_no, block_no);
+  CommonCmdPacket ccp;
+  CCP_UTIL_ACK ret = CCP_form_block_deploy_cmd(&ccp, tl_no, block_no);
   if (ret != CCP_UTIL_ACK_OK)
   {
     return CCP_make_cmd_ret_without_err_code(CCP_EXEC_PACKET_FMT_ERR);
   }
 
-  return PH_dispatch_command(&CCP_util_packet_);
+  return PH_dispatch_command(&ccp);
 }
 
 


### PR DESCRIPTION
## 概要
`CCP_form_and_exec_*` を再帰的に実行し，かつ，コマンド実行時に CCP の一部（raw paramなど）をポインタ等で引き回したときに，`common_cmd_packet_util.c` で static に確保されている CCP が意図せず上書きされ，バグが発生する．
したがって，ここでの CCP を static 確保ではなく，スタック確保に変更する．

なお，C2Aではもともとスタック不足ランタイムエラーを回避するために，サイズの大きいパケット構造体は静的に確保することが多かったが，これを機に見直す．
実行コストの観点からは，サイズの大きい変数をスタックにつむことはコストはない．一方で，ランタイムエラーの問題はのこるので， README に「必要環境」を追加した．

## issue
- https://github.com/arkedge/c2a-core/issues/303

## 補足
@sksat @ToshiAki64 これと次のPR（他の静的確保 CCP，CTP を消すPR）をもって v4.2.1 をだしたいです．
