### PR TITLE
static に確保している packet 系の変数をローカル変数にする

### DIFF
--- a/applications/divided_cmd_utility.c
+++ b/applications/divided_cmd_utility.c
@@ -71,8 +71,6 @@ static void DCU_create_log_on_front_(CMD_CODE cmd_code);
 static DividedCmdUtility divided_cmd_utility_;
 const DividedCmdUtility* const divided_cmd_utility = &divided_cmd_utility_;
 
-static CommonCmdPacket DCU_packet_;
-
 
 AppInfo DCU_create_app(void)
 {
@@ -208,14 +206,15 @@ DCU_ACK DCU_register_next(CMD_CODE cmd_code, const uint8_t* param, uint16_t len)
 {
   uint8_t idx;
   CCP_UTIL_ACK ret;
+  CommonCmdPacket ccp;
 
   DCU_move_to_front_in_log_(cmd_code);
   idx = divided_cmd_utility_.exec_log_order[0];
   divided_cmd_utility_.exec_logs[idx].status = DCU_STATUS_PROGRESS;
 
-  ret = CCP_form_rtc(&DCU_packet_, cmd_code, param, len);
+  ret = CCP_form_rtc(&ccp, cmd_code, param, len);
   if (ret != CCP_UTIL_ACK_OK) return DCU_ACK_ERR;
-  if (PH_analyze_cmd_packet(&DCU_packet_) != PH_ACK_SUCCESS)
+  if (PH_analyze_cmd_packet(&ccp) != PH_ACK_SUCCESS)
   {
     return DCU_ACK_ERR;
   }

--- a/tlm_cmd/block_command_executor.c
+++ b/tlm_cmd/block_command_executor.c
@@ -16,8 +16,6 @@
 #include "../system/time_manager/time_manager.h"
 #include "common_cmd_packet_util.h"
 
-static CommonCmdPacket BCE_packet_;
-
 static BlockCommandExecutor block_command_executor_;
 const BlockCommandExecutor* const block_command_executor = &block_command_executor_;
 
@@ -227,6 +225,7 @@ static CCP_CmdRet BCE_rotate_block_cmd_(bct_id_t block)
 {
   BCE_Params* bc_exe_params;
   BCT_Pos pos;
+  CommonCmdPacket ccp;
 
   if (block >= BCT_MAX_BLOCKS) return BCT_convert_bct_ack_to_ccp_cmd_ret(BCT_INVALID_BLOCK_NO);
 
@@ -249,8 +248,8 @@ static CCP_CmdRet BCE_rotate_block_cmd_(bct_id_t block)
   BCE_set_bc_exe_params_(block, bc_exe_params);
 
   BCT_make_pos(&pos, block, bc_exe_params->rotate.next_cmd);
-  BCT_load_cmd(&pos, &BCE_packet_);
-  return PH_dispatch_command(&BCE_packet_);
+  BCT_load_cmd(&pos, &ccp);
+  return PH_dispatch_command(&ccp);
 }
 
 CCP_CmdRet Cmd_BCE_COMBINE_BLOCK(const CommonCmdPacket* packet)
@@ -273,6 +272,7 @@ static CCP_CmdRet BCE_combine_block_cmd_(bct_id_t block)
 {
   uint8_t cmd;
   uint8_t length;
+  CommonCmdPacket ccp;
 
   if (block >= BCT_MAX_BLOCKS) return BCT_convert_bct_ack_to_ccp_cmd_ret(BCT_INVALID_BLOCK_NO);
 
@@ -287,8 +287,8 @@ static CCP_CmdRet BCE_combine_block_cmd_(bct_id_t block)
 
     pos.block = block;
     pos.cmd = cmd;
-    BCT_load_cmd(&pos, &BCE_packet_);
-    cmd_ret = PH_dispatch_command(&BCE_packet_);
+    BCT_load_cmd(&pos, &ccp);
+    cmd_ret = PH_dispatch_command(&ccp);
 
     if (cmd_ret.exec_sts != CCP_EXEC_SUCCESS) return cmd_ret;
   }
@@ -323,6 +323,7 @@ static CCP_CmdRet BCE_timelimit_combine_block_cmd_(bct_id_t block, step_t limit_
   uint8_t cmd;
   uint8_t length;
   BCE_Params* bc_exe_params;
+  CommonCmdPacket ccp;
 
   ObcTime start = TMGR_get_master_clock();
   ObcTime finish;
@@ -352,8 +353,8 @@ static CCP_CmdRet BCE_timelimit_combine_block_cmd_(bct_id_t block, step_t limit_
 
     pos.block = block;
     pos.cmd = cmd;
-    BCT_load_cmd(&pos, &BCE_packet_);
-    cmd_ret = PH_dispatch_command(&BCE_packet_);
+    BCT_load_cmd(&pos, &ccp);
+    cmd_ret = PH_dispatch_command(&ccp);
 
     if (cmd_ret.exec_sts != CCP_EXEC_SUCCESS)
     {

--- a/tlm_cmd/block_command_table.c
+++ b/tlm_cmd/block_command_table.c
@@ -522,7 +522,7 @@ CCP_CmdRet Cmd_BCT_OVERWRITE_CMD(const CommonCmdPacket* packet)
 // パス運用時に使用するので, 一応厳密にしておいたほうがいい気もする.
 CCP_CmdRet Cmd_BCT_FILL_NOP(const CommonCmdPacket* packet)
 {
-  static CommonCmdPacket temp_packet_;
+  CommonCmdPacket temp_packet;
   cycle_t ti;
   uint8_t num_nop = CCP_get_param_from_packet(packet, 0, uint8_t);
 
@@ -531,8 +531,8 @@ CCP_CmdRet Cmd_BCT_FILL_NOP(const CommonCmdPacket* packet)
 
   for (ti = 11 - (cycle_t)num_nop; ti < 11; ++ti)
   {
-    CCP_form_tlc(&temp_packet_, ti, Cmd_CODE_NOP, NULL, 0);
-    BCT_register_cmd(&temp_packet_);
+    CCP_form_tlc(&temp_packet, ti, Cmd_CODE_NOP, NULL, 0);
+    BCT_register_cmd(&temp_packet);
   }
 
   return CCP_make_cmd_ret_without_err_code(CCP_EXEC_SUCCESS);

--- a/tlm_cmd/ccsds/aos_space_data_link_protocol/tcp_to_m_pdu.c
+++ b/tlm_cmd/ccsds/aos_space_data_link_protocol/tcp_to_m_pdu.c
@@ -61,10 +61,10 @@ T2M_ACK T2M_form_m_pdu(TcpToMPdu* tcp_to_m_pdu, PacketList* pl, MultiplexingProt
         // この場合、生成されたFill Packetは次M_PDUにまたがる。
         // この状態で追加のテレメトリが生成されない場合は、Fill
         // Packetのみで構成されたM_PDUが一度送出されることになる。
-        static TlmSpacePacket fill_; // サイズが大きいため静的確保(スタック保護)
+        TlmSpacePacket fill;
         size_t fill_size = M_PDU_DATA_SIZE - tcp_to_m_pdu->m_pdu_wp;
-        TSP_setup_fill_packet(&fill_, (uint16_t)fill_size);
-        PL_push_back(pl, &fill_);
+        TSP_setup_fill_packet(&fill, (uint16_t)fill_size);
+        PL_push_back(pl, &fill);
       }
     }
 

--- a/tlm_cmd/command_dispatcher.c
+++ b/tlm_cmd/command_dispatcher.c
@@ -112,7 +112,7 @@ static void CDIS_clear_exec_info_(CDIS_ExecInfo* exec_info)
 
 void CDIS_dispatch_command(CommandDispatcher* cdis)
 {
-  static CommonCmdPacket packet_; // パケットコピー用．サイズが大きいため静的変数として宣言
+  CommonCmdPacket packet; // パケットコピー用
 
   // 実行有効フラグが無効化されている場合は処理打ち切り
   if (cdis->lockout) return;
@@ -130,7 +130,7 @@ void CDIS_dispatch_command(CommandDispatcher* cdis)
   }
 
   // 実行すべきコマンドパケットを取得
-  packet_ = *(const CommonCmdPacket*)(PL_get_head(cdis->pl)->packet);
+  packet = *(const CommonCmdPacket*)(PL_get_head(cdis->pl)->packet);
 
   // ここで実行種別を変更するのをやめた．
   // - MOBCから配送される第二OBCにも，GS cmdやTL cmdを送信したいため
@@ -141,13 +141,13 @@ void CDIS_dispatch_command(CommandDispatcher* cdis)
   // タイムラインはここでリアルタイムに変換される。
   // この処理は特に複数機器でパケットルーティングを行う場合重要。
   // 普通はルーティング先はルーティング元のタイムラインを受け付けないはず。
-  CCP_set_exec_type(&packet_, CCP_EXEC_TYPE_RT);
+  CCP_set_exec_type(&packet, CCP_EXEC_TYPE_RT);
   */
 
   // 実行時情報を記録しつつコマンドを実行
   cdis->prev.time    = TMGR_get_master_clock();
-  cdis->prev.code    = CCP_get_id(&packet_);
-  cdis->prev.cmd_ret = PH_dispatch_command(&packet_);
+  cdis->prev.code    = CCP_get_id(&packet);
+  cdis->prev.cmd_ret = PH_dispatch_command(&packet);
 
   // 実行したコマンドをリストから破棄
   PL_drop_executed(cdis->pl);

--- a/tlm_cmd/packet_handler.c
+++ b/tlm_cmd/packet_handler.c
@@ -297,7 +297,7 @@ static PH_ACK PH_add_tl_cmd_(TLCD_ID id,
 
 static PH_ACK PH_add_utl_cmd_(TLCD_ID id, const CommonCmdPacket* packet)
 {
-  static CommonCmdPacket temp_; // サイズが大きいため静的領域に確保
+  CommonCmdPacket temp;
 
   // utl_unixtime : time_manager.h の utl_unixtime_epoch_ を参照
   // UTL_cmd ではパケットヘッダーの ti の部分に utl_unixtime が格納されている
@@ -305,11 +305,11 @@ static PH_ACK PH_add_utl_cmd_(TLCD_ID id, const CommonCmdPacket* packet)
   cycle_t ti = TMGR_get_ti_from_utl_unixtime(utl_unixtime);
 
   // TL_cmd に変換して tl_cmd_list に追加する
-  CCP_copy_packet(&temp_, packet);
-  CCP_set_ti(&temp_, ti);
-  CCP_set_exec_type(&temp_, CCP_EXEC_TYPE_TL_FROM_GS); // UTL -> TL
+  CCP_copy_packet(&temp, packet);
+  CCP_set_ti(&temp, ti);
+  CCP_set_exec_type(&temp, CCP_EXEC_TYPE_TL_FROM_GS); // UTL -> TL
 
-  return PH_add_tl_cmd_(id, &temp_, TMGR_get_master_total_cycle());
+  return PH_add_tl_cmd_(id, &temp, TMGR_get_master_total_cycle());
 }
 
 

--- a/tlm_cmd/packet_list.c
+++ b/tlm_cmd/packet_list.c
@@ -32,9 +32,6 @@ static PL_Node* PL_get_free_node_(PacketList* pl);
 static PL_ACK PL_drop_head_(PacketList* pl);
 
 
-static CommonCmdPacket PL_ccp_; // サイズが大きいため静的領域に確保
-
-
 PL_ACK PL_initialize(PL_Node* pl_node_stock,
                      void* packet_stock,
                      uint16_t node_num,
@@ -291,6 +288,7 @@ PL_ACK PL_drop_node(PacketList* pl, PL_Node* prev, PL_Node* current)
 // FIXME: PL にあるのがおかしくて， TL 周りのどこかで検索して， insert を実行すべき
 PL_ACK PL_insert_tl_cmd(PacketList* pl, const CommonCmdPacket* packet, cycle_t now)
 {
+  CommonCmdPacket ccp;
   cycle_t head, tail;
   cycle_t planed = CCP_get_ti(packet);
 
@@ -298,12 +296,12 @@ PL_ACK PL_insert_tl_cmd(PacketList* pl, const CommonCmdPacket* packet, cycle_t n
 
   // TL に保存される Cmd の Sequence Count は 0 とする ( Digset のため)
   // FIXME: CSP 依存を CCP 依存にする
-  CCP_copy_packet(&PL_ccp_, packet);
-  CSP_set_seq_count((CmdSpacePacket*)&PL_ccp_, 0);
+  CCP_copy_packet(&ccp, packet);
+  CSP_set_seq_count((CmdSpacePacket*)&ccp, 0);
 
   if (now > planed) return PL_TLC_PAST_TIME;
   if (PL_is_full(pl)) return PL_LIST_FULL;
-  if (PL_is_empty(pl)) return PL_push_front(pl, &PL_ccp_);
+  if (PL_is_empty(pl)) return PL_push_front(pl, &ccp);
 
   // 以下，他コマンドが登録されているとき
   head = CCP_get_ti( (const CommonCmdPacket*)(PL_get_head(pl)->packet) );
@@ -311,11 +309,11 @@ PL_ACK PL_insert_tl_cmd(PacketList* pl, const CommonCmdPacket* packet, cycle_t n
 
   if (tail < planed) // 他のどれより遅い
   {
-    return PL_push_back(pl, &PL_ccp_);
+    return PL_push_back(pl, &ccp);
   }
   else if (head > planed) // 他のどれより早い
   {
-    return PL_push_front(pl, &PL_ccp_);
+    return PL_push_front(pl, &ccp);
   }
   else if (head == planed || tail == planed) // 時刻指定が等しい
   {
@@ -339,7 +337,7 @@ PL_ACK PL_insert_tl_cmd(PacketList* pl, const CommonCmdPacket* packet, cycle_t n
       }
       else if (curr_ti > planed) // 挿入場所発見
       {
-        PL_insert_after(pl, prev, &PL_ccp_);
+        PL_insert_after(pl, prev, &ccp);
         return PL_SUCCESS;
       }
       else // 既登録コマンドと時刻指定が等しい
@@ -380,23 +378,24 @@ PL_ACK PL_deploy_block_cmd(PacketList* pl, const bct_id_t block, cycle_t start_a
 
   for (i = 0; i < bc_length; ++i)
   {
+    CommonCmdPacket ccp;
     BCT_Pos pos;
     PL_ACK ack = PL_SUCCESS;
 
     // コマンドを読みだし、TLCとして実行時刻を設定
     BCT_make_pos(&pos, block, i);
-    BCT_load_cmd(&pos, &PL_ccp_);
-    CCP_set_ti(&PL_ccp_, (cycle_t)(start_at + adj + CCP_get_ti(&PL_ccp_)));
-    CCP_set_exec_type(&PL_ccp_, CCP_EXEC_TYPE_TL_FROM_GS); // BLC -> TLC   // FIXME: TaskListやBC用TLM用もすべて CCP_EXEC_TYPE_TL_FROM_GS になってしまうので, わかりにくい
+    BCT_load_cmd(&pos, &ccp);
+    CCP_set_ti(&ccp, (cycle_t)(start_at + adj + CCP_get_ti(&ccp)));
+    CCP_set_exec_type(&ccp, CCP_EXEC_TYPE_TL_FROM_GS); // BLC -> TLC   // FIXME: TaskListやBC用TLM用もすべて CCP_EXEC_TYPE_TL_FROM_GS になってしまうので, わかりにくい
 
     for (j = 0; j <= pl->active_nodes_; ++j)
     {
       // コマンドをTLCに登録を試みる
-      ack = PL_insert_tl_cmd(pl, &PL_ccp_, start_at);
+      ack = PL_insert_tl_cmd(pl, &ccp, start_at);
       if (ack != PL_TLC_ALREADY_EXISTS) break;    // PL_SUCCESS なはず． TODO: 一応 event 発行しておく？
 
       // 同一時刻で既に登録されていた場合は時刻をずらして再登録
-      CCP_set_ti(&PL_ccp_, CCP_get_ti(&PL_ccp_) + 1);
+      CCP_set_ti(&ccp, CCP_get_ti(&ccp) + 1);
       ++adj; // 累積調整時間を更新する
     }
     if (ack != PL_SUCCESS) return ack;


### PR DESCRIPTION
## 概要
- https://github.com/arkedge/c2a-core/pull/301 に引き続き，static な packet 定義をスタックにのるローカル変数にする
- 全体的なメモリ使用量はかなり減るはず（スタック保護の観点的には不利にはなる）

## 検証
CI が通ればOK


## issue
- https://github.com/arkedge/c2a-core/issues/303

## 備考
- [ ] v4.2.1 をだす
- [x] https://github.com/arkedge/c2a-core/pull/301 を先にマージする