### PR TITLE
MOBC やsub OBC を想定したコードをビルド対象に加えるためのビルドオプションを追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,10 @@ option(C2A_USE_ALL_CORE_APPS        "Use C2A-core all Applications" ON)
 option(C2A_USE_ALL_CORE_TEST_APPS   "Use C2A-core all Test Applications" ON)
 option(C2A_USE_ALL_CORE_LIB         "Use C2A-core all library" ON)
 
+## C2A build target board option （標準実装などがこのオプションによってスイッチされる）
+option(C2A_ADD_SRC_FOR_MOBC         "Add src intended for MOBC to build target" OFF)
+option(C2A_ADD_SRC_FOR_SUBOBC       "Add src intended for sub OBC to build target" OFF)
+
 ## C2A CCSDS select
 # See alse; /docs/core/ccsds.md
 option(C2A_USE_CORE_CCSDS_AOS_SPACE_DATA_LINK_PROTOCOL  "Use C2A-core CCSDS AOS SPACE DATA LINK PROTOCOL implementation" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ option(C2A_USE_ALL_CORE_LIB         "Use C2A-core all library" ON)
 
 ## C2A build target board option （標準実装などがこのオプションによってスイッチされる）
 option(C2A_ADD_SRC_FOR_MOBC         "Add src intended for MOBC to build target" OFF)
-option(C2A_ADD_SRC_FOR_SUBOBC       "Add src intended for sub OBC to build target" OFF)
+option(C2A_ADD_SRC_FOR_SUB_OBC      "Add src intended for sub OBC to build target" OFF)
 
 ## C2A CCSDS select
 # See alse; /docs/core/ccsds.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ option(C2A_USE_ALL_CORE_TEST_APPS   "Use C2A-core all Test Applications" ON)
 option(C2A_USE_ALL_CORE_LIB         "Use C2A-core all library" ON)
 
 ## C2A build target board option （標準実装などがこのオプションによってスイッチされる．デフォルトでは sub OBC を想定）
-option(C2A_ENABLE_MOBC_FEATURES     "Enable some features for MOBC" OFF)
+option(C2A_MOBC_FEATURES            "Enable some features for MOBC" OFF)
 
 ## C2A CCSDS select
 # See alse; /docs/core/ccsds.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,8 @@ option(C2A_USE_ALL_CORE_APPS        "Use C2A-core all Applications" ON)
 option(C2A_USE_ALL_CORE_TEST_APPS   "Use C2A-core all Test Applications" ON)
 option(C2A_USE_ALL_CORE_LIB         "Use C2A-core all library" ON)
 
-## C2A build target board option （標準実装などがこのオプションによってスイッチされる）
-option(C2A_ADD_SRC_FOR_MOBC         "Add src intended for MOBC to build target" OFF)
-option(C2A_ADD_SRC_FOR_SUB_OBC      "Add src intended for sub OBC to build target" OFF)
+## C2A build target board option （標準実装などがこのオプションによってスイッチされる．デフォルトでは sub OBC を想定）
+option(C2A_ENABLE_MOBC_FEATURES     "Enable some features for MOBC" OFF)
 
 ## C2A CCSDS select
 # See alse; /docs/core/ccsds.md


### PR DESCRIPTION
## 概要
https://github.com/arkedge/c2a-core/issues/305 のための準備．
デフォルト実装を core で提供するとき，MOBC か sub OBC かのどちらを意図してるコードかを切り替えるために用いる

あわせて，ビルドオプションのドキュメントも多少整備した．

## Issue
NA

## 影響範囲
この PR ではこのオプションを利用するコードは追加されてないため，なし

## 備考
- [x] v4.3.0 が出たあとに， rebase してマージする
- [x] https://github.com/arkedge/c2a-core/pull/317 を先にマージする