### PR TITLE
[code_generator] コード生成時に不要な空白を除去する

### DIFF
--- a/code-generator/my_mod/cmd_def.py
+++ b/code-generator/my_mod/cmd_def.py
@@ -33,8 +33,8 @@ def GenerateCmdDef(settings, sgc_db):
         comment = sgc_db[i][0]
         name = sgc_db[i][1]
         cmd_id = sgc_db[i][3]
-        description = sgc_db[i][19].strip()
-        note = sgc_db[i][20].strip()
+        description = sgc_db[i][19]
+        note = sgc_db[i][20]
         if comment == "" and name == "":  # CommentもNameも空白なら打ち切り
             break
         if comment != "":  # Comment
@@ -132,7 +132,7 @@ def GenerateBctDef(settings, bct_db):
 
         # エスケープ解除
         name = name.replace("@@", ",")
-        description = description.replace("@@", ",").strip()
+        description = description.replace("@@", ",")
 
         if comment == "" and name == "":  # CommentもNameも空白なら打ち切り
             break
@@ -183,8 +183,8 @@ def GenerateOtherObcCmdDef(settings, other_obc_dbs):
             comment = sgc_db[j][0]
             name = sgc_db[j][1]
             cmd_id = sgc_db[j][3]
-            description = sgc_db[j][19].strip()
-            note = sgc_db[j][20].strip()
+            description = sgc_db[j][19]
+            note = sgc_db[j][20]
             if comment == "" and name == "":  # CommentもNameも空白なら打ち切り
                 break
             if comment != "":  # Comment

--- a/code-generator/my_mod/load_db.py
+++ b/code-generator/my_mod/load_db.py
@@ -35,10 +35,10 @@ def LoadCmdCSV_(cmd_db_path, db_prefix, encoding):
 
     with open(sgc_db_path, mode="r", encoding=encoding) as fh:
         reader = csv.reader(fh)
-        sgc_db = [row for row in reader]
+        sgc_db = [[s.strip() for s in row] for row in reader]
     with open(bct_db_path, mode="r", encoding=encoding) as fh:
         reader = csv.reader(fh)
-        bct_db = [row for row in reader]
+        bct_db = [[s.strip() for s in row] for row in reader]
 
     return sgc_db, bct_db
 
@@ -76,7 +76,7 @@ def LoadTlmCSV_(tlm_db_path, db_prefix, tlm_id_range, encoding):
         tlm_sheet_path = tlm_db_path + db_prefix + "_TLM_DB_" + tlm_name + ".csv"
         with open(tlm_sheet_path, mode="r", encoding=encoding) as fh:
             reader = csv.reader(fh)
-            sheet = [row for row in reader]
+            sheet = [[s.strip() for s in row] for row in reader]
             # pprint.pprint(sheet)
             # print(sheet)
             enable_flag = sheet[2][2]  # FIXME: Enable/Disable を取得．マジックナンバーで指定してしまってる．

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
@@ -5,7 +5,7 @@
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
  *          CSV files MD5:  7bd311e714ca9b903ba0bfe4bb4538ea
- *          db commit hash: a078a98e408dc9a9c419fabfa330f5b5d58970d0
+ *          db commit hash: 4306070d794a99f525d9d1d5738f747f01c64776
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_command_definitions.h
@@ -4,8 +4,8 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
- *          CSV files MD5:  7bd311e714ca9b903ba0bfe4bb4538ea
- *          db commit hash: 4306070d794a99f525d9d1d5738f747f01c64776
+ *          CSV files MD5:  0e38aad788fca6fba1d44684152ac1a2
+ *          db commit hash: e1e6b79acd85523f04266f1c08b7a3b89e5b6e05
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
@@ -6,7 +6,7 @@
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
  *          CSV files MD5:  7bd311e714ca9b903ba0bfe4bb4538ea
- *          db commit hash: a078a98e408dc9a9c419fabfa330f5b5d58970d0
+ *          db commit hash: 4306070d794a99f525d9d1d5738f747f01c64776
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.c
@@ -5,8 +5,8 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
- *          CSV files MD5:  7bd311e714ca9b903ba0bfe4bb4538ea
- *          db commit hash: 4306070d794a99f525d9d1d5738f747f01c64776
+ *          CSV files MD5:  0e38aad788fca6fba1d44684152ac1a2
+ *          db commit hash: e1e6b79acd85523f04266f1c08b7a3b89e5b6e05
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
@@ -5,7 +5,7 @@
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
  *          CSV files MD5:  7bd311e714ca9b903ba0bfe4bb4538ea
- *          db commit hash: a078a98e408dc9a9c419fabfa330f5b5d58970d0
+ *          db commit hash: 4306070d794a99f525d9d1d5738f747f01c64776
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_buffer.h
@@ -4,8 +4,8 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
- *          CSV files MD5:  7bd311e714ca9b903ba0bfe4bb4538ea
- *          db commit hash: 4306070d794a99f525d9d1d5738f747f01c64776
+ *          CSV files MD5:  0e38aad788fca6fba1d44684152ac1a2
+ *          db commit hash: e1e6b79acd85523f04266f1c08b7a3b89e5b6e05
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
@@ -5,7 +5,7 @@
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
  *          CSV files MD5:  7bd311e714ca9b903ba0bfe4bb4538ea
- *          db commit hash: a078a98e408dc9a9c419fabfa330f5b5d58970d0
+ *          db commit hash: 4306070d794a99f525d9d1d5738f747f01c64776
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_data_definitions.h
@@ -4,8 +4,8 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
- *          CSV files MD5:  7bd311e714ca9b903ba0bfe4bb4538ea
- *          db commit hash: 4306070d794a99f525d9d1d5738f747f01c64776
+ *          CSV files MD5:  0e38aad788fca6fba1d44684152ac1a2
+ *          db commit hash: e1e6b79acd85523f04266f1c08b7a3b89e5b6e05
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
@@ -5,7 +5,7 @@
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
  *          CSV files MD5:  7bd311e714ca9b903ba0bfe4bb4538ea
- *          db commit hash: a078a98e408dc9a9c419fabfa330f5b5d58970d0
+ *          db commit hash: 4306070d794a99f525d9d1d5738f747f01c64776
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
+++ b/examples/mobc/src/src_user/component_driver/aocs/aobc_telemetry_definitions.h
@@ -4,8 +4,8 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:     github.com/arkedge/c2a-core.git
- *          CSV files MD5:  7bd311e714ca9b903ba0bfe4bb4538ea
- *          db commit hash: 4306070d794a99f525d9d1d5738f747f01c64776
+ *          CSV files MD5:  0e38aad788fca6fba1d44684152ac1a2
+ *          db commit hash: e1e6b79acd85523f04266f1c08b7a3b89e5b6e05
  * @note  コード生成パラメータ:
  *          name:                    AOBC
  *          db_prefix:               SAMPLE_AOBC

--- a/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:    github.com/arkedge/c2a-core.git
- *          CSV files MD5: 3a91627656a5aa6c359adf43e76aa20e
+ *          CSV files MD5: a6ac3f58e1422615904c43d389e64877
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -22,7 +22,7 @@ typedef enum
   // Block Cmds for Mode Transition (シーケンスリスト)
   // ./src_user/settings/modes/transitions/ で定義
   BC_SL_START_UP_TO_INITIAL = 0,
-  BC_SL_NOP  = 17,
+  BC_SL_NOP = 17,
 
   // Block Cmds for TaskList (タスクリスト) : 286-300
   // ./src_user/settings/modes/task_lists/ で定義

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:    github.com/arkedge/c2a-core.git
- *          CSV files MD5: 3a91627656a5aa6c359adf43e76aa20e
+ *          CSV files MD5: a6ac3f58e1422615904c43d389e64877
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:    github.com/arkedge/c2a-core.git
- *          CSV files MD5: 3a91627656a5aa6c359adf43e76aa20e
+ *          CSV files MD5: a6ac3f58e1422615904c43d389e64877
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:    github.com/arkedge/c2a-core.git
- *          CSV files MD5: 3a91627656a5aa6c359adf43e76aa20e
+ *          CSV files MD5: a6ac3f58e1422615904c43d389e64877
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/mobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:    github.com/arkedge/c2a-core.git
- *          CSV files MD5: 3a91627656a5aa6c359adf43e76aa20e
+ *          CSV files MD5: a6ac3f58e1422615904c43d389e64877
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_MOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/mobc/tlm-cmd-db/CMD_DB/SAMPLE_MOBC_CMD_DB_BCT.csv
+++ b/examples/mobc/tlm-cmd-db/CMD_DB/SAMPLE_MOBC_CMD_DB_BCT.csv
@@ -3,7 +3,7 @@ Comment,Name,ShortName,BCID,エイリアス,,,,,Danger Flag,Description,Note
 **,Block Cmds for Mode Transition (シーケンスリスト),,,,,,,,,,
 *,./src_user/settings/modes/transitions/ で定義,,,,,,,,,,
 ,BC_SL_START_UP_TO_INITIAL,,0,,,,,,danger,,
-,BC_SL_NOP ,,17,,,,,,danger,,
+,BC_SL_NOP,,17,,,,,,danger,,
 **,Block Cmds for TaskList (タスクリスト) : 286-300,,,,,,,,,,
 *,./src_user/settings/modes/task_lists/ で定義,,,,,,,,,,
 ,BC_TL_START_UP,,20,,,,,,danger,,

--- a/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:    github.com/arkedge/c2a-core.git
- *          CSV files MD5: 7bd311e714ca9b903ba0bfe4bb4538ea
+ *          CSV files MD5: 0e38aad788fca6fba1d44684152ac1a2
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/block_command_definitions.h
@@ -22,7 +22,7 @@ typedef enum
   // Block Cmds for Mode Transition (シーケンスリスト)
   // ./src_user/settings/modes/transitions/ で定義
   BC_SL_START_UP_TO_INITIAL = 0,
-  BC_SL_NOP  = 17,
+  BC_SL_NOP = 17,
 
   // Block Cmds for TaskList (タスクリスト) : 286-300
   // ./src_user/settings/modes/task_lists/ で定義

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:    github.com/arkedge/c2a-core.git
- *          CSV files MD5: 7bd311e714ca9b903ba0bfe4bb4538ea
+ *          CSV files MD5: 0e38aad788fca6fba1d44684152ac1a2
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/command_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:    github.com/arkedge/c2a-core.git
- *          CSV files MD5: 7bd311e714ca9b903ba0bfe4bb4538ea
+ *          CSV files MD5: 0e38aad788fca6fba1d44684152ac1a2
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.c
@@ -5,7 +5,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:    github.com/arkedge/c2a-core.git
- *          CSV files MD5: 7bd311e714ca9b903ba0bfe4bb4538ea
+ *          CSV files MD5: 0e38aad788fca6fba1d44684152ac1a2
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
+++ b/examples/subobc/src/src_user/tlm_cmd/telemetry_definitions.h
@@ -4,7 +4,7 @@
  * @note  このコードは自動生成されています！
  * @note  コード生成元 tlm-cmd-db:
  *          repository:    github.com/arkedge/c2a-core.git
- *          CSV files MD5: 7bd311e714ca9b903ba0bfe4bb4538ea
+ *          CSV files MD5: 0e38aad788fca6fba1d44684152ac1a2
  * @note  コード生成パラメータ:
  *          db_prefix:             SAMPLE_AOBC
  *          tlm_id_range:          [0x00, 0x100]

--- a/examples/subobc/tlm-cmd-db/CMD_DB/SAMPLE_AOBC_CMD_DB_BCT.csv
+++ b/examples/subobc/tlm-cmd-db/CMD_DB/SAMPLE_AOBC_CMD_DB_BCT.csv
@@ -3,7 +3,7 @@ Comment,Name,ShortName,BCID,エイリアス,,,,,Danger Flag,Description,Note
 **,Block Cmds for Mode Transition (シーケンスリスト),,,,,,,,,,
 *,./src_user/settings/modes/transitions/ で定義,,,,,,,,,,
 ,BC_SL_START_UP_TO_INITIAL,,0,,,,,,danger,,
-,BC_SL_NOP ,,17,,,,,,danger,,
+,BC_SL_NOP,,17,,,,,,danger,,
 **,Block Cmds for TaskList (タスクリスト) : 286-300,,,,,,,,,,
 *,./src_user/settings/modes/task_lists/ で定義,,,,,,,,,,
 ,BC_TL_START_UP,,20,,,,,,danger,,


### PR DESCRIPTION
## 概要
- https://github.com/arkedge/c2a-core/pull/312 で気になった微修正
- DB読み込み時の処理に strip を追加した


## 検証結果
CI がとおって，コード生成できればOK

## 影響範囲
csv のセルにたいして strip するようにしたので，コード生成結果から不要な空白がなくなっている