### PR TITLE
CI で利用する S2E Core のバージョンを上げる

### DIFF
--- a/.github/workflows/build_with_s2e.yml
+++ b/.github/workflows/build_with_s2e.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   # renovate: datasource=github-releases depName=ut-issl/s2e-core
-  S2E_CORE_VERSION: v7.2.0
+  S2E_CORE_VERSION: v7.2.5
 
 jobs:
   build_s2e_win:


### PR DESCRIPTION


## 詳細
- https://github.com/arkedge/c2a-core/pull/310 が S2E Core の実験的機能である Command Sender に対して Breaking だった．そのため S2E Build CI がとおらなくなった
- その修正のための https://github.com/ut-issl/s2e-core/pull/619 （Command Sender がデフォルトで OFF になる）を取り込むために S2E Core のバージョンを上げる
- なお，抜本解決には https://github.com/ut-issl/s2e-core/pull/610 が必要．


<!--
## 注意
- 関連する Projects が存在する場合，それの紐付けを行うこと
- Assignees を設定すること
- 可能ならば Reviewers を設定すること
- 可能ならば `priority` ラベルを付けること
-->
