### PR TITLE
Add rust-toolchain override config

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.76.0"
+targets = ["i686-unknown-linux-gnu"]


### PR DESCRIPTION
## 概要
`rust-toolchain.toml` をリポジトリに追加し，c2a-core リポジトリ内で使用する Rust のバージョン及び target toolchain を固定します

## Issue
- #326 

## 詳細
- これにより，c2a-core 開発時の Rust のバージョンが固定されます
  - また，target の指定もしたため，checkout 後に `rustup target add i686-unknown-linux-gnu` する必要が無くなります
- #326 に対する暫定的対処として，最新の stable の 1.77.0 ではなく 1.76.0 を指定しています

## 検証結果
Rust CI が通ればよし

## 影響範囲
Rust CI および `c2a-core` crate など Rust エコシステムを使っているもの