### PR TITLE
Example user CMake config is not only for SILS-S2E

### DIFF
--- a/examples/mobc/CMakeLists.txt
+++ b/examples/mobc/CMakeLists.txt
@@ -1,5 +1,3 @@
-## CMake file for S2E integration
-
 cmake_minimum_required(VERSION 3.13)
 project(C2A)
 

--- a/examples/subobc/CMakeLists.txt
+++ b/examples/subobc/CMakeLists.txt
@@ -1,5 +1,3 @@
-## CMake file for S2E integration
-
 cmake_minimum_required(VERSION 3.13)
 project(C2A)
 


### PR DESCRIPTION
## 概要
SSIA

## 詳細
今は SILS-c2a-dev-runtime や実機向けビルドでも使うため、古い記述となっている