### PR TITLE
bindgen C2A RESULT type

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -26,6 +26,8 @@ fn main() {
     bind("hal".into(), "spi.h");
     bind("hal".into(), "uart.h");
     bind("hal".into(), "wdt.h");
+
+    bind("library".into(), "result.h");
 }
 
 fn bind(module: PathBuf, header: &str) {

--- a/c2a_core.rs
+++ b/c2a_core.rs
@@ -10,6 +10,7 @@ use core::*;
 include!(concat!(env!("OUT_DIR"), "/c2a_core_main.rs"));
 
 pub mod hal;
+pub mod library;
 pub mod system;
 
 #[cfg(feature = "export-src")]

--- a/library/mod.rs
+++ b/library/mod.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/result.rs"));


### PR DESCRIPTION
## 概要
SSIA

## 詳細
- `library/result.h` を bindgen して `c2a_core::library::RESULT` として Rust 側に公開する
- Rust 側でC言語側から呼び出すコードを実装することが多く、その際のエラー返却を容易にするため

## 影響範囲
c2a-core crate