### PR TITLE
Tell c2a-core crate re-build condition to cargo

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,22 @@ use semver::Version;
 use clang::{token::TokenKind::Punctuation, Clang, Index};
 
 fn main() {
+    println!("cargo:return-if-changed=setup.bat");
+    println!("cargo:return-if-changed=setup.sh");
+
+    println!("cargo:return-if-changed=CMakeLists.txt");
+    println!("cargo:return-if-changed=common.cmake");
+
+    println!("cargo:return-if-changed=c2a_core_main.h");
+    println!("cargo:return-if-changed=c2a_core_main.c");
+
+    println!("cargo:return-if-changed=applications/");
+    println!("cargo:return-if-changed=component_driver/");
+    println!("cargo:return-if-changed=hal/");
+    println!("cargo:return-if-changed=library/");
+    println!("cargo:return-if-changed=system/");
+    println!("cargo:return-if-changed=tlm_cmd/");
+
     let ver = env!("CARGO_PKG_VERSION");
     let ver = Version::parse(ver).unwrap();
     dbg!(&ver);


### PR DESCRIPTION
## Issue / PR
- #344 

## 詳細
- `c2a-core` crate のビルドの際に、Rust 関連以外のファイルの更新を Cargo に伝える
- 実用上は `c2a-core` crate のファイルが更新され、しかもそれが bindgen する対象のものであることはほぼないため、これが C2A user にとって有用なことはほぼない
- `c2a-core` crate の開発時のため

## 影響範囲
c2a-core crate のビルド