### PR TITLE
Add C99 build option to example users

### DIFF
--- a/examples/mobc/CMakeLists.txt
+++ b/examples/mobc/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.13)
 project(C2A)
 
 # options
+# C2A 全体を C99 としてビルドするかどうか
+option(C2A_BUILD_AS_C99 "Build C2A as C99" OFF)
+
 # SCI COM for connection to WINGS TMTC IF
 # ！！！注意！！！
 # これをONにした状態で，SCIの受け口がない場合（TMTC IFが動いてない状態）

--- a/examples/subobc/CMakeLists.txt
+++ b/examples/subobc/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.13)
 project(C2A)
 
 # options
+# C2A 全体を C99 としてビルドするかどうか
+option(C2A_BUILD_AS_C99 "Build C2A as C99" OFF)
+
 # SCI COM for connection to WINGS TMTC IF
 # ！！！注意！！！
 # これをONにした状態で，SCIの受け口がない場合（TMTC IFが動いてない状態）


### PR DESCRIPTION
## 概要
C99 のビルドオプションを example user に明示的に追加する

## Issue
- #346 

## 詳細
- 現状でも、C2A user 全体は（CMake でのビルドであれば）`C2A_BUILD_AS_C99` オプションで C99 ビルドを有効化できる（この実態は `common.cmake` にあるため）
- しかしこれは暗黙的なものになってしまっており、C2A user で C99 ビルドを有効化する際に @sksat が毎回同様の設定を追加して回っている
- `C2A_BUILD_AS_C99` を example user にオプションとして追加することで存在を明示する
- この PR ではあくまで存在の明示のみ行い、C99 ビルドの推奨化（= C89 ビルド非推奨の明示）は別途行う
  - これをまだ行わない理由は C2A user 的には全く無い
  - c2a-core の C89 の限定的なサポートを適切に継続するための準備を別途行うため
    - 具体的には、（c2a-core の単体ビルドはできないので）c2a-core の C89 でのビルド健全性チェックのため、C89・C99 両方での example user の Build-CI を整備する必要がある

## 検証結果
- example user で `cmake -B build -DC2A_BUILD_AS_C99=ON; cmake --build build` して C99 でビルドされるようになる
- example user で `cmake -B build; cmake --build build` して、まだ C89 でビルドされる

## 影響範囲
example user のビルド