### PR TITLE
Make example user C99-Build default

### DIFF
--- a/examples/mobc/CMakeLists.txt
+++ b/examples/mobc/CMakeLists.txt
@@ -3,7 +3,8 @@ project(C2A)
 
 # options
 # C2A 全体を C99 としてビルドするかどうか
-option(C2A_BUILD_AS_C99 "Build C2A as C99" OFF)
+# c2a-core はまだ引き続き（限定的に）C89 のサポートは行うが、特に事情が無い限り C99 でのビルドを強く推奨する
+option(C2A_BUILD_AS_C99 "Build C2A as C99" ON)
 
 # SCI COM for connection to WINGS TMTC IF
 # ！！！注意！！！

--- a/examples/subobc/CMakeLists.txt
+++ b/examples/subobc/CMakeLists.txt
@@ -3,7 +3,8 @@ project(C2A)
 
 # options
 # C2A 全体を C99 としてビルドするかどうか
-option(C2A_BUILD_AS_C99 "Build C2A as C99" OFF)
+# c2a-core はまだ引き続き（限定的に）C89 のサポートは行うが、特に事情が無い限り C99 でのビルドを強く推奨する
+option(C2A_BUILD_AS_C99 "Build C2A as C99" ON)
 
 # SCI COM for connection to WINGS TMTC IF
 # ！！！注意！！！


### PR DESCRIPTION
## 概要
example user のビルドのデフォルト設定を C99 にする

## Issue / PR
- #346 
- #348 
- #349 

## 詳細
- C89 な C2A user は非常に限定的
  - 存在はするため c2a-core 本体としてのサポートはまだ切らない
- 一方で、特段の事情が無ければ C2A を C89 としてビルドしたい理由はまったく無い
  - そもそも現状「サポート」しているのは正確には C89 そのものではない（ex: C89 には `//` のコメントは無い）
  - ↑のため、C89 規格での厳格なチェックにかけると不要な warning が大量に出る
    - warning を無視してしまう理由となっている
- 標準の `stdint.h` を使えないのはあまりにも不便（https://github.com/ut-issl/c2a-core/pull/511 ）

## 検証結果
- C89/C99 双方のビルドが通ればよし: #349 

## 影響範囲
example user のビルド

## 補足
- #349 の後にマージする