### PR TITLE
chore: add repository to bind-utils package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace.package]
 version = "4.4.0"
+repository = "https://github.com/arkedge/c2a-core"
 
 [workspace]
 resolver = "2"
@@ -36,7 +37,7 @@ description = "Core of Command Centric Architecture"
 readme = "README.md"
 license = "MIT"
 
-repository = "https://github.com/arkedge/c2a-core"
+repository.workspace = true
 documentation = "https://ut-issl.github.io/c2a-reference/c2a-core"
 
 [lib]

--- a/library/bind-utils/Cargo.toml
+++ b/library/bind-utils/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "c2a-bind-utils"
 description = "C2Aのモジュールをbindgenするときのユーティリティ"
+repository.workspace = true
 version.workspace = true
 edition = "2021"
 


### PR DESCRIPTION
## 概要
c2a-bind-utils crate の package metadata に repository を追加

## Issue
なし

## 詳細

* crates.io に公開されている [c2a-bind-utils](https://crates.io/crates/c2a-bind-utils) に repository が登録されていない
    * 他の arkedge が管理している crate では登録されているので、bind-utils にも追加した
* `repository.workspace` として参照するために、toplevel(c2a-core) の repository 指定を `[workspace.package]` に移動した


## 検証結果

うまい検証方法が思いつかず、できていない。 (権限があれば、`cargo publish --dryr-run` 等?)

## 影響範囲

ない想定


<!--
## 注意
- 関連する Projects が存在する場合，それの紐付けを行うこと
- Assignees を設定すること
- 可能ならば Reviewers を設定すること
- 可能ならば `priority` ラベルを付けること
-->
