### PR TITLE
Fix link in c2a_dev_runtime.md

### DIFF
--- a/docs/sils/c2a_dev_runtime.md
+++ b/docs/sils/c2a_dev_runtime.md
@@ -60,8 +60,8 @@ pnpm run devtools:debug
 ### pytest の実行
 以下を参照のこと．
 
-- [mobc pytest](../../examples/mobc/src/src_user/Test/README.md)
-- [subobc pytest](../../examples/subobc/src/src_user/Test/README.md)
+- [mobc pytest](../../examples/mobc/src/src_user/test/README.md)
+- [subobc pytest](../../examples/subobc/src/src_user/test/README.md)
 
 
 ## その他


### PR DESCRIPTION
ディレクトリの大文字・小文字を変更した ( https://github.com/arkedge/c2a-core/pull/20 ) ことに伴う，修正漏れ