### PR TITLE
cargo build with --locked option on Actions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -98,12 +98,12 @@ jobs:
       if: matrix.c2a_user == 'subobc'
       working-directory: ./examples/mobc
       run: |
-        cargo build
+        cargo build --locked
 
     - name: build C2A
       working-directory: ./examples/${{ matrix.c2a_user }}
       run: |
-        cargo build
+        cargo build --locked
 
     - name: run mobc C2A
       if: matrix.c2a_user == 'mobc'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,7 +40,7 @@ jobs:
         uses: sksat/action-clippy@v1.1.0
         with:
           reporter: ${{ github.event_name == 'pull_request' && 'github-pr-review' || 'github-check' }}
-          clippy_flags: --workspace --all-features
+          clippy_flags: --workspace --all-features --locked
 
       - name: format
         run: cargo fmt --all -- --check


### PR DESCRIPTION
- 関連: #401 
- https://github.com/arkedge/c2a-core/issues/401#issuecomment-2576983744 の `home` crate の MSRV が上がったことによってビルドがコケるようになったのは、lockfile 中の dependencies に入っていた `home` の最新バージョンが自動で使われるようになったことによるもの
- 上記の問題の対処は #404 で行ったが、それはそれとして、lockfile があればこのような自体は防げたので #406 で lockfile を追加した
- ただし、このままでは「気がついたら main の CI がコケていた」という事態は依然として発生しうるので、CI のビルドは lockfile を参照して行うようにする