### PR TITLE
Specify Rust toolchain version in CI with rust-toolchain.toml

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -68,8 +68,14 @@ jobs:
           ./examples/mobc/tools/.crates2.json
         key: ${{ matrix.c2a_user }}-${{ runner.os }}-tools-${{ hashFiles('${{ matrix.c2a_user }}/tools/install.sh', '${{ matrix.c2a_user }}/tools/package.json') }}
 
+    - name: Get Rust toolchain
+      id: toolchain
+      run: |
+        awk -F'[ ="]+' '$1 == "channel" { print "toolchain=" $2 }' rust-toolchain.toml >> "$GITHUB_OUTPUT"
+
     - uses: dtolnay/rust-toolchain@stable
       with:
+        toolchain: ${{ steps.toolchain.outputs.toolchain }}
         targets: i686-unknown-linux-gnu
         components: clippy, rustfmt
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,9 +24,14 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y gcc-multilib g++-multilib
 
+      - name: Get Rust toolchain
+        id: toolchain
+        run: |
+          awk -F'[ ="]+' '$1 == "channel" { print "toolchain=" $2 }' rust-toolchain.toml >> "$GITHUB_OUTPUT"
+
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ steps.toolchain.outputs.toolchain }}
           targets: i686-unknown-linux-gnu
           components: clippy, rustfmt
 


### PR DESCRIPTION
- Fixes #401 
- 雑な stable 指定ではなく、明示的に `rust-toolchain.toml` に書いてあるバージョンの toolchain をセットアップするようにする