### PR TITLE
Force set home crate to 0.5.9

### DIFF
--- a/library/bind-utils/Cargo.toml
+++ b/library/bind-utils/Cargo.toml
@@ -9,3 +9,6 @@ license = "MIT"
 [dependencies]
 bindgen = "0.69.4"
 doxygen-rs = "0.4.2"
+
+# force set version to *NOT* to update MSRV by PATCH VERSION to build with Rust 1.76
+home = "=0.5.9"


### PR DESCRIPTION
- Fixes #401 
- https://github.com/arkedge/c2a-core/issues/401#issuecomment-2576983744 は `home` crate が **patch update** で MSRV を上げたことによるもの
  - その上で、`examples/mobc` などでは lockfile を固定していなかったため、dependencies を lock してビルドすることができなかった
  - また、できたところで clippy などでは lib crate もビルド対象となるので無意味
- どうにもならないが、Rust 1.76.0 ~ 1.81.0 の間には 1.79.0 があり、これは https://github.com/rust-lang/cargo/pull/12783 を踏み抜く
  - なので、無理矢理 Rust 1.81.0 にジャンプするのは些か乱暴すぎる
- そのため、`home` crate のバージョンを MSRV が上がる前のものに patch version まで明示的に固定し、Rust 1.76.0 でもビルドできるようにする
- patch update で MSRV を上げるな