### PR TITLE
コマンドのパケット配送での EL 発行の追加

### DIFF
--- a/system/event_manager/event_logger.h
+++ b/system/event_manager/event_logger.h
@@ -218,6 +218,8 @@ typedef enum
   EL_CORE_GROUP_CDIS_INTERNAL_ERR,
   EL_CORE_GROUP_CDIS_EXEC_ERR_STS,
   EL_CORE_GROUP_CDIS_EXEC_ERR_CODE,
+  EL_CORE_GROUP_PH_ANALYZE_CCP,       //!< PH_analyze_cmd_packet での CCP 配送エラー
+  EL_CORE_GROUP_PH_USER_ANALYZE_CCP,  //!< PH_user_analyze_cmd での CCP 配送エラー
   // TODO: ComponentDriverSuper
 #ifdef EL_IS_ENABLE_EL_ERROR_LEVEL
   EL_CORE_GROUP_EL_DROP_CLOG1,        //!< EL CLogs で古いエラーを上書きするとき (group, err_level を保存)

--- a/tlm_cmd/packet_handler.c
+++ b/tlm_cmd/packet_handler.c
@@ -208,6 +208,8 @@ PH_ACK PH_analyze_cmd_packet(const CommonCmdPacket* packet)
   case PH_ACK_BC_SUCCESS:
     // 成功ケース
     return ack;
+  default:
+    break;
   }
 
   // ここまで来たら以下のどれか

--- a/tlm_cmd/packet_list.c
+++ b/tlm_cmd/packet_list.c
@@ -337,8 +337,7 @@ PL_ACK PL_insert_tl_cmd(PacketList* pl, const CommonCmdPacket* packet, cycle_t n
       }
       else if (curr_ti > planed) // 挿入場所発見
       {
-        PL_insert_after(pl, prev, &ccp);
-        return PL_SUCCESS;
+        return PL_insert_after(pl, prev, &ccp);
       }
       else // 既登録コマンドと時刻指定が等しい
       {


### PR DESCRIPTION
## 概要
コマンドのパケット配送（Driver からうけとって，各種 cmd キューに格納するまで）でパケットが失われる場合に，EL HIGH を発行するようにする

## Issue
- https://github.com/arkedge/c2a-core/issues/412

## 詳細
issue に詳細


