### PR TITLE
テレメのパケット配送での EL 発行の追加

### DIFF
--- a/system/event_manager/event_logger.h
+++ b/system/event_manager/event_logger.h
@@ -220,6 +220,7 @@ typedef enum
   EL_CORE_GROUP_CDIS_EXEC_ERR_CODE,
   EL_CORE_GROUP_PH_ANALYZE_CCP,       //!< PH_analyze_cmd_packet での CCP 配送エラー
   EL_CORE_GROUP_PH_USER_ANALYZE_CCP,  //!< PH_user_analyze_cmd での CCP 配送エラー
+  EL_CORE_GROUP_PH_ANALYZE_CTP,       //!< PH_analyze_tlm_packet での CTP 配送エラー
   // TODO: ComponentDriverSuper
 #ifdef EL_IS_ENABLE_EL_ERROR_LEVEL
   EL_CORE_GROUP_EL_DROP_CLOG1,        //!< EL CLogs で古いエラーを上書きするとき (group, err_level を保存)

--- a/tlm_cmd/packet_handler.c
+++ b/tlm_cmd/packet_handler.c
@@ -409,10 +409,10 @@ static PH_ACK PH_add_tlm_to_pl(const CommonTlmPacket* packet, PacketList* pl, CT
   if (ack != PL_SUCCESS)
   {
     EL_record_event((EL_GROUP)EL_CORE_GROUP_PH_ANALYZE_CTP,
-                    (uint32_t)( ((0X000000ff & (uint32_t)dest_flag) << 16) | ( 0x0000ffff & (uint32_t)ack) ),
+                    (uint32_t)( ((0X000000ff & (uint32_t)dest_flag) << 16) | ( 0x0000ffff & (uint32_t)PH_ACK_PL_LIST_FULL) ),
                     EL_ERROR_LEVEL_HIGH,      // packet が失われるので HIGH
                     CTP_get_id(packet));
-    return ack;    // PH_ACK_PL_LIST_FULL のはず
+    return PH_ACK_PL_LIST_FULL;
   }
 
   // 複数の配送先に配送されるパケットの分岐は終わっているため， dest flag を配送先のもののみにする．

--- a/tlm_cmd/packet_handler.c
+++ b/tlm_cmd/packet_handler.c
@@ -275,7 +275,7 @@ PH_ACK PH_analyze_tlm_packet(const CommonTlmPacket* packet)
   // High Priority Realtime Telemetry
   if (flags & CTP_DEST_FLAG_HP_TLM)
   {
-    ack = PH_add_rt_tlm_(packet);  // hp_tlm のフラグが立っていても，RT_TLMとして処理する方針にした
+    ack = PH_add_rt_tlm_(packet);  // hp_tlm のフラグが立っていても，RT_TLM として処理する方針にした
     if (ack != PH_ACK_SUCCESS) last_err_ack = ack;
   }
 


### PR DESCRIPTION
## 概要
テレメのパケット配送（Tlm Generator や DR などからうけとって，各種 tlm キューに格納するまで）でパケットが失われる場合に，EL を発行するようにする

## Issue
- https://github.com/arkedge/c2a-core/issues/412

## 詳細
issue に詳細

## 備考
base branch が https://github.com/arkedge/c2a-core/pull/416 になってるので，こちらを先にマージする
