### PR TITLE
Update Rust to 1.78.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.78.0"
 targets = ["i686-unknown-linux-gnu"]


### PR DESCRIPTION
- Rust 1.83.0 から、lockfile v4 が default になった
  - https://github.com/rust-lang/cargo/pull/14595
- ところで、Renovate が依存を更新する時は、内部で `cargo update` が叩かれている
  - そして、（おそらく）Renovate のコンテナが抱えている Rust のバージョンで更新が行われる
  - Cargo.lock が v4 になった状態で commit される
- しかし、lockfile v4 は 1.78.0 で stabilize された
  - ということは、Rust 1.77.0 以前では v4 な `Cargo.lock`が発生するとビルドがコケる
- そのため、一旦 1.78.0 に上げる