### PR TITLE
Configure c2a-core crate MSRV & set to 1.78

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ c2a-uart-kble = { path = "./hal/uart-kble" }
 name = "c2a-core"
 version.workspace = true
 edition = "2021"
+rust-version = "1.78.0"
 
 description = "Core of Command Centric Architecture"
 readme = "README.md"


### PR DESCRIPTION
- #424 でこのリポジトリの rustup の設定で Rust のバージョンを 1.78.0 に上げた
- これは lockfile v4 に伴う（Rust 側の）breaking change によるもの
  - 正確には後方互換性はあるのだが、デフォルトで出力される lockfile が v4 になった（かつ、Renovate がそれに伴って v4 にしてくるようになった）ことによって、事実上の breaking change となっている
- しかし一方で、これはこのリポジトリ内の設定でしかなく、C2A user には波及しない設定となっている
- そして、今回 Rust version を 1.78.0 にしたのは、全社的な MSRV を 1.78.0 とするため
- これを実際の（C2A user 含めた）ビルドにも波及させるため、明示的に MSRV を設定し、このバージョンも 1.78.0 とする