### PR TITLE
example: Install missing kble-serialport

### DIFF
--- a/examples/mobc/boom-tools/install.sh
+++ b/examples/mobc/boom-tools/install.sh
@@ -9,6 +9,7 @@ curl -L --proto '=https' --tlsv1.2 -sSf "https://raw.githubusercontent.com/cargo
 
 ./bin/cargo-binstall --root . tlmcmddb-cli           --version 2.6.1 --no-confirm
 ./bin/cargo-binstall --root . kble                   --version 0.3.0 --no-confirm
+./bin/cargo-binstall --root . kble-serialport        --version 0.3.0 --no-confirm
 ./bin/cargo-binstall --root . kble-c2a               --version 0.3.0 --no-confirm
 ./bin/cargo-binstall --root . kble-eb90              --version 0.3.0 --no-confirm
 

--- a/examples/subobc/boom-tools/install.sh
+++ b/examples/subobc/boom-tools/install.sh
@@ -9,6 +9,7 @@ curl -L --proto '=https' --tlsv1.2 -sSf "https://raw.githubusercontent.com/cargo
 
 ./bin/cargo-binstall --root . tlmcmddb-cli           --version 2.6.1 --no-confirm
 ./bin/cargo-binstall --root . kble                   --version 0.3.0 --no-confirm
+./bin/cargo-binstall --root . kble-serialport        --version 0.3.0 --no-confirm
 ./bin/cargo-binstall --root . kble-c2a               --version 0.3.0 --no-confirm
 ./bin/cargo-binstall --root . kble-eb90              --version 0.3.0 --no-confirm
 


### PR DESCRIPTION
- example user の C2A Boom 環境で、`kble-serialport` がインストールされていなかったので追加
  - SILS のみで開発している時は不要だが、実機を含む開発時にはあると便利
  - `package.json` ではインストールしていることになっていたので、不整合が発生していた