### PR TITLE
fix(examples/mobc): Enable cross-platform builds with auto-target detection

### DIFF
--- a/examples/mobc/.cargo/config.toml
+++ b/examples/mobc/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-target = "i686-unknown-linux-gnu"

--- a/examples/mobc/boom-tools/install.sh
+++ b/examples/mobc/boom-tools/install.sh
@@ -5,7 +5,7 @@ export JRSONNET_VERSION="v0.5.0-pre96-test"
 
 curl -L --proto '=https' --tlsv1.2 -sSf "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/${BINSTALL_VERSION}/install-from-binstall-release.sh" | env BINSTALL_VERSION=${BINSTALL_VERSION} CARGO_HOME=$(pwd) bash
 
-./bin/cargo-binstall --root . tmtc-c2a               --version 1.1.1 --no-confirm
+./bin/cargo-binstall --root . tmtc-c2a               --version 1.2.0 --no-confirm
 
 ./bin/cargo-binstall --root . tlmcmddb-cli           --version 2.6.1 --no-confirm
 ./bin/cargo-binstall --root . kble                   --version 0.4.2 --no-confirm
@@ -17,7 +17,13 @@ curl -L --proto '=https' --tlsv1.2 -sSf "https://raw.githubusercontent.com/cargo
 arch=$(uname -m)
 if [ "$arch" = "x86_64" ]; then
   arch="amd64"
+elif [ "$arch" = "arm64" ]; then
+  arch="aarch64"
 fi
 os=$(uname -s | tr -s '[:upper:]' '[:lower:]')
-curl -L "https://github.com/CertainLach/jrsonnet/releases/download/${JRSONNET_VERSION}/jrsonnet-linux-${arch}" -o ./bin/jrsonnet
+if [ "$os" = "darwin" ]; then
+  curl -L "https://github.com/CertainLach/jrsonnet/releases/download/${JRSONNET_VERSION}/jrsonnet-darwin-${arch}" -o ./bin/jrsonnet
+else
+  curl -L "https://github.com/CertainLach/jrsonnet/releases/download/${JRSONNET_VERSION}/jrsonnet-linux-${arch}" -o ./bin/jrsonnet
+fi
 chmod +x ./bin/jrsonnet

--- a/examples/mobc/build.rs
+++ b/examples/mobc/build.rs
@@ -1,9 +1,23 @@
 fn main() {
+    // Auto-detect target architecture and set appropriate build flags
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86_64".to_string());
+    let build_for_32bit = match target_arch.as_str() {
+        "i686" | "i586" | "arm" => "ON",
+        _ => "OFF",
+    };
+    
     // Build C2A & link
     let mut c2a_cmake = cmake::Config::new(".");
+    
+    // Use system default compiler for macOS
+    if cfg!(target_os = "macos") {
+        c2a_cmake.define("CMAKE_C_COMPILER", "clang");
+        c2a_cmake.define("CMAKE_CXX_COMPILER", "clang++");
+    }
+    
     let libc2a = c2a_cmake
         .very_verbose(true)
-        .define("C2A_BUILD_FOR_32BIT", "OFF")
+        .define("C2A_BUILD_FOR_32BIT", build_for_32bit)
         .define("C2A_BUILD_AS_C99", "ON")
         .define("C2A_BUILD_FOR_SILS", "ON")
         .define("C2A_USE_SCI_COM_WINGS", "OFF")

--- a/examples/mobc/package.json
+++ b/examples/mobc/package.json
@@ -3,7 +3,7 @@
   "packageManager": "pnpm@9.1.1",
   "scripts": {
     "build:tlmcmddb": "tlmcmddb-cli bundle --pretty tlm-cmd-db/TLM_DB/calced_data tlm-cmd-db/CMD_DB tlmcmddb.json",
-    "run:c2a": "cargo run",
+    "run:c2a": "cargo run --target $(rustc -vV | grep host | cut -d' ' -f2)",
     "run:gaia": "tmtc-c2a --satconfig satconfig.json --tlmcmddb tlmcmddb.json",
     "run:kble": "bash -c 'while :; do kble -s <(jrsonnet spaghetti.jsonnet); sleep 1; done'",
     "run-all": "run-p run:*",


### PR DESCRIPTION
## 概要
macosで環境構築した際にクレートのバージョン、プラットフォーム間のバイナリ差分があり起動に失敗したため対応したPE

## Issue
- 関連する issue

## 詳細
#### 発生した問題

  1. 依存関係の互換性エラー
  - tmtc-c2a v1.1.1 が古い gaia-ccsds-c2a v1.0.0 を使用
  - Telemetry 型に entries フィールドが存在しないコンパイルエラー

  2. プラットフォーム固有バイナリの問題
  - jrsonnet がLinux用バイナリをダウンロードしていたが、macOS ARM64環境で実行しており、「Not Found」エラーで実行できない

  3. クロスコンパイル設定の問題
  - .cargo/config.toml で i686-unknown-linux-gnu が固定で設定されていた
  - macOSに i686-linux-gnu-gcc クロスコンパイラが未インストール
  - CMakeが存在しないコンパイラを要求

  #### 実施した解決策

  1. 依存関係の更新
  boom-tools/install.sh
  前: tmtc-c2a --version 1.1.1
  後:  tmtc-c2a --version 1.2.0

  2. プラットフォーム自動判定機能
  boom-tools/install.sh に下記を追加
```
  if [ "$os" = "darwin" ]; then
    curl -L "...jrsonnet-darwin-${arch}" -o ./bin/jrsonnet
  else
    curl -L "...jrsonnet-linux-${arch}" -o ./bin/jrsonnet
  fi
```

  4. 自動ターゲット検出
```
  // package.json
  "run:c2a": "cargo run --target $(rustc -vV | grep host | cut -d' ' -f2)"

  // build.rs
  if cfg!(target_os = "macos") {
      c2a_cmake.define("CMAKE_C_COMPILER", "clang");
      c2a_cmake.define("CMAKE_CXX_COMPILER", "clang++");
  }

  # .cargo/config.toml
  [build]
  # 固定ターゲットをコメントアウトし、自動検出に変更
```


## 検証結果
test へのリンクや，検証結果へのリンク

## 影響範囲
XX系の動作がガラッと変わる，とか．

## 補足
何かあれば

<!--
## 注意
- 関連する Projects が存在する場合，それの紐付けを行うこと
- Assignees を設定すること
- 可能ならば Reviewers を設定すること
- 可能ならば `priority` ラベルを付けること
-->
