### PR TITLE
Update Rust version & MSRV to 1.81.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ c2a-uart-kble = { path = "./hal/uart-kble" }
 name = "c2a-core"
 version.workspace = true
 edition = "2021"
-rust-version = "1.78.0"
+rust-version = "1.81.0"
 
 description = "Core of Command Centric Architecture"
 readme = "README.md"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.81.0"
 targets = ["i686-unknown-linux-gnu"]


### PR DESCRIPTION
c2a-core v4.5.0 にて、依存 crate である `home` crate の MSRV に追従できていなかったことにより `cargo publish` ができていなかった。そのため、MSRV を 1.81.0 まで上げる。