### PR TITLE
fix unintended fallthrough in TLM_MGR_check_same_cmd_

### DIFF
--- a/applications/telemetry_manager.c
+++ b/applications/telemetry_manager.c
@@ -928,6 +928,7 @@ static RESULT TLM_MGR_check_same_cmd_(const TLM_MGR_CmdElem* cmd_elem,
     {
       return RESULT_OK;
     }
+    break;
   case TLM_MGR_CMD_TYPE_TG_FORWARD_AS_ST_TLM:
     if (cmd_elem->cmd_type == TLM_MGR_CMD_TYPE_TG_FORWARD_AS_ST_TLM &&
         cmd_elem->apid == apid &&
@@ -936,12 +937,14 @@ static RESULT TLM_MGR_check_same_cmd_(const TLM_MGR_CmdElem* cmd_elem,
     {
       return RESULT_OK;
     }
+    break;
   case TLM_MGR_CMD_TYPE_DR_REPLAY_TLM:
     if (cmd_elem->cmd_type == TLM_MGR_CMD_TYPE_DR_REPLAY_TLM &&
         cmd_elem->dr_partition == dr_partition)
     {
       return RESULT_OK;
     }
+    break;
   case TLM_MGR_CMD_TYPE_UNREGISTERED:   // FALLTHROUGH
   default:
     return RESULT_ERR;


### PR DESCRIPTION
## Issue
- https://github.com/arkedge/c2a-core/issues/465

## 検証結果
- テレメマネージャーにて、期待通りに cmd_elem の登録・削除ができる事
  - c2a-core には DR アプリが無いため、c2a-core を用いている別リポジトリ環境にて同様の修正を行い動作検証を行った

使用したコマンド群
```ops
 @RT.MOBC TLM_MGR_CLEAR_USER_TLM
 wait 5s
 @RT.MOBC TLM_MGR_REGISTER_REPLAY_TLM 1 2
 wait 5s
 @RT.MOBC TLM_MGR_REGISTER_FORWARD_AS_ST_TLM 1 0x511 tlmid!(AOBC.AOBC_HK_xx) 2
 wait 5s
 @RT.MOBC TLM_MGR_DELETE_FORWARD_AS_ST_TLM 1 0x511 tlmid!(AOBC.AOBC_HK_xx) 2
 wait 5s
 @RT.MOBC TLM_MGR_DELETE_REPLAY_TLM 1 2
```

## 補足

