### PR TITLE
Add assert for BCT_CMD_MAX_LENGTH

### DIFF
--- a/tlm_cmd/block_command_table.h
+++ b/tlm_cmd/block_command_table.h
@@ -37,6 +37,10 @@ typedef uint32_t bct_id_t;
 
 #include "./common_packet/common_cmd_packet.h" // bct_id_t の定義よりあとにinclude
 
+#if BCT_CMD_MAX_LENGTH > CCP_MAX_LEN
+#error BCT_CMD_MAX_LENGTH should be less than or equal to CCP_MAX_LEN
+#endif
+
 /*
 Block Command Table は
 BCT_MAX_BLOCKS x BCT_MAX_CMD_NUM


### PR DESCRIPTION
## 概要
BCT_CMD_MAX_LENGTH の設定値が確実に CCP の最大長よりも短くなるためのアサーションを追加

## Issue
NA

## 詳細
これがないと，もし BCT_CMD_MAX_LENGTH が CCP 最大長よりも大きな値が設定されていると（普通はメモリが無駄なのでそんな設定にはしない），BCT への cmd packet の memcpy のときにセグフォしてしまう．

## 検証結果
CI がとおればOK