### PR TITLE
feat(bcl): return BCT_ACK from BCL_tool_register_* functions

### DIFF
--- a/tlm_cmd/block_command_loader.c
+++ b/tlm_cmd/block_command_loader.c
@@ -85,6 +85,7 @@ BCT_ACK BCL_tool_register_cmd_to_other_obc(cycle_t ti, APID apid, CMD_CODE cmd_i
 
 BCT_ACK BCL_tool_register_rotate(cycle_t ti, bct_id_t bct_id)
 {
+  BCT_ACK ack;
 #if SIZE_OF_BCT_ID_T == 1
   BCL_tool_prepare_param_uint8(bct_id);
 #elif SIZE_OF_BCT_ID_T == 2
@@ -95,13 +96,14 @@ BCT_ACK BCL_tool_register_rotate(cycle_t ti, bct_id_t bct_id)
 #error Illegal value for SIZE_OF_BCT_ID_T
 #endif
 
-  BCT_ACK ack = BCL_register_cmd_(ti, Cmd_CODE_BCE_ROTATE_BLOCK);
+  ack = BCL_register_cmd_(ti, Cmd_CODE_BCE_ROTATE_BLOCK);
   BCL_clear_info_();
   return ack;
 }
 
 BCT_ACK BCL_tool_register_combine(cycle_t ti, bct_id_t bct_id)
 {
+  BCT_ACK ack;
 #if SIZE_OF_BCT_ID_T == 1
   BCL_tool_prepare_param_uint8(bct_id);
 #elif SIZE_OF_BCT_ID_T == 2
@@ -112,13 +114,14 @@ BCT_ACK BCL_tool_register_combine(cycle_t ti, bct_id_t bct_id)
 #error Illegal value for SIZE_OF_BCT_ID_T
 #endif
 
-  BCT_ACK ack = BCL_register_cmd_(ti, Cmd_CODE_BCE_COMBINE_BLOCK);
+  ack = BCL_register_cmd_(ti, Cmd_CODE_BCE_COMBINE_BLOCK);
   BCL_clear_info_();
   return ack;
 }
 
 BCT_ACK BCL_tool_register_limit_combine(cycle_t ti, bct_id_t bct_id, step_t limit_step)
 {
+  BCT_ACK ack;
 #if SIZE_OF_BCT_ID_T == 1
   BCL_tool_prepare_param_uint8(bct_id);
 #elif SIZE_OF_BCT_ID_T == 2
@@ -131,13 +134,14 @@ BCT_ACK BCL_tool_register_limit_combine(cycle_t ti, bct_id_t bct_id, step_t limi
 
   BCL_tool_prepare_param_uint8((uint8_t)limit_step);
 
-  BCT_ACK ack = BCL_register_cmd_(ti, Cmd_CODE_BCE_TIMELIMIT_COMBINE_BLOCK);
+  ack = BCL_register_cmd_(ti, Cmd_CODE_BCE_TIMELIMIT_COMBINE_BLOCK);
   BCL_clear_info_();
   return ack;
 }
 
 BCT_ACK BCL_tool_register_deploy(cycle_t ti, bct_id_t bct_id, TLCD_ID tlcd_id)
 {
+  BCT_ACK ack;
   BCL_tool_prepare_param_uint8((uint8_t)tlcd_id);
 
 #if SIZE_OF_BCT_ID_T == 1
@@ -150,7 +154,7 @@ BCT_ACK BCL_tool_register_deploy(cycle_t ti, bct_id_t bct_id, TLCD_ID tlcd_id)
 #error Illegal value for SIZE_OF_BCT_ID_T
 #endif
 
-  BCT_ACK ack = BCL_register_cmd_(ti, Cmd_CODE_TLCD_DEPLOY_BLOCK);
+  ack = BCL_register_cmd_(ti, Cmd_CODE_TLCD_DEPLOY_BLOCK);
   BCL_clear_info_();
   return ack;
 }

--- a/tlm_cmd/block_command_loader.c
+++ b/tlm_cmd/block_command_loader.c
@@ -17,9 +17,9 @@
 
 #define BCL_PARAM_MAX_LENGTH BCT_CMD_MAX_LENGTH
 
-static void BCL_register_cmd_(cycle_t ti, CMD_CODE cmd_id);
-static void BCL_register_cmd_to_other_obc_(cycle_t ti, APID apid, CMD_CODE cmd_id);
-static void BCL_register_app_(cycle_t ti, AR_APP_ID app_id);
+static BCT_ACK BCL_register_cmd_(cycle_t ti, CMD_CODE cmd_id);
+static BCT_ACK BCL_register_cmd_to_other_obc_(cycle_t ti, APID apid, CMD_CODE cmd_id);
+static BCT_ACK BCL_register_app_(cycle_t ti, AR_APP_ID app_id);
 static void BCL_clear_info_(void);
 
 
@@ -69,35 +69,21 @@ void BCL_safe_load_sl(bct_id_t pos, void (*BCL_load_func)(void))
 }
 #endif
 
-void BCL_tool_register_cmd(cycle_t ti, CMD_CODE cmd_id)
+BCT_ACK BCL_tool_register_cmd(cycle_t ti, CMD_CODE cmd_id)
 {
-  BCL_register_cmd_(ti, cmd_id);
+  BCT_ACK ack = BCL_register_cmd_(ti, cmd_id);
   BCL_clear_info_();
+  return ack;
 }
 
-void BCL_tool_register_cmd_to_other_obc(cycle_t ti, APID apid, CMD_CODE cmd_id)
+BCT_ACK BCL_tool_register_cmd_to_other_obc(cycle_t ti, APID apid, CMD_CODE cmd_id)
 {
-  BCL_register_cmd_to_other_obc_(ti, apid, cmd_id);
+  BCT_ACK ack = BCL_register_cmd_to_other_obc_(ti, apid, cmd_id);
   BCL_clear_info_();
+  return ack;
 }
 
-void BCL_tool_register_rotate(cycle_t ti, bct_id_t bct_id)
-{
-#if SIZE_OF_BCT_ID_T == 1
-  BCL_tool_prepare_param_uint8(bct_id);
-#elif SIZE_OF_BCT_ID_T == 2
-  BCL_tool_prepare_param_uint16(bct_id);
-#elif SIZE_OF_BCT_ID_T == 4
-  BCL_tool_prepare_param_uint32(bct_id);
-#else
-#error Illegal value for SIZE_OF_BCT_ID_T
-#endif
-
-  BCL_register_cmd_(ti, Cmd_CODE_BCE_ROTATE_BLOCK);
-  BCL_clear_info_();
-}
-
-void BCL_tool_register_combine(cycle_t ti, bct_id_t bct_id)
+BCT_ACK BCL_tool_register_rotate(cycle_t ti, bct_id_t bct_id)
 {
 #if SIZE_OF_BCT_ID_T == 1
   BCL_tool_prepare_param_uint8(bct_id);
@@ -109,11 +95,29 @@ void BCL_tool_register_combine(cycle_t ti, bct_id_t bct_id)
 #error Illegal value for SIZE_OF_BCT_ID_T
 #endif
 
-  BCL_register_cmd_(ti, Cmd_CODE_BCE_COMBINE_BLOCK);
+  BCT_ACK ack = BCL_register_cmd_(ti, Cmd_CODE_BCE_ROTATE_BLOCK);
   BCL_clear_info_();
+  return ack;
 }
 
-void BCL_tool_register_limit_combine(cycle_t ti, bct_id_t bct_id, step_t limit_step)
+BCT_ACK BCL_tool_register_combine(cycle_t ti, bct_id_t bct_id)
+{
+#if SIZE_OF_BCT_ID_T == 1
+  BCL_tool_prepare_param_uint8(bct_id);
+#elif SIZE_OF_BCT_ID_T == 2
+  BCL_tool_prepare_param_uint16(bct_id);
+#elif SIZE_OF_BCT_ID_T == 4
+  BCL_tool_prepare_param_uint32(bct_id);
+#else
+#error Illegal value for SIZE_OF_BCT_ID_T
+#endif
+
+  BCT_ACK ack = BCL_register_cmd_(ti, Cmd_CODE_BCE_COMBINE_BLOCK);
+  BCL_clear_info_();
+  return ack;
+}
+
+BCT_ACK BCL_tool_register_limit_combine(cycle_t ti, bct_id_t bct_id, step_t limit_step)
 {
 #if SIZE_OF_BCT_ID_T == 1
   BCL_tool_prepare_param_uint8(bct_id);
@@ -127,11 +131,12 @@ void BCL_tool_register_limit_combine(cycle_t ti, bct_id_t bct_id, step_t limit_s
 
   BCL_tool_prepare_param_uint8((uint8_t)limit_step);
 
-  BCL_register_cmd_(ti, Cmd_CODE_BCE_TIMELIMIT_COMBINE_BLOCK);
+  BCT_ACK ack = BCL_register_cmd_(ti, Cmd_CODE_BCE_TIMELIMIT_COMBINE_BLOCK);
   BCL_clear_info_();
+  return ack;
 }
 
-void BCL_tool_register_deploy(cycle_t ti, bct_id_t bct_id, TLCD_ID tlcd_id)
+BCT_ACK BCL_tool_register_deploy(cycle_t ti, bct_id_t bct_id, TLCD_ID tlcd_id)
 {
   BCL_tool_prepare_param_uint8((uint8_t)tlcd_id);
 
@@ -145,14 +150,16 @@ void BCL_tool_register_deploy(cycle_t ti, bct_id_t bct_id, TLCD_ID tlcd_id)
 #error Illegal value for SIZE_OF_BCT_ID_T
 #endif
 
-  BCL_register_cmd_(ti, Cmd_CODE_TLCD_DEPLOY_BLOCK);
+  BCT_ACK ack = BCL_register_cmd_(ti, Cmd_CODE_TLCD_DEPLOY_BLOCK);
   BCL_clear_info_();
+  return ack;
 }
 
-void BCL_tool_register_app(cycle_t ti, AR_APP_ID app_id)
+BCT_ACK BCL_tool_register_app(cycle_t ti, AR_APP_ID app_id)
 {
-  BCL_register_app_(ti, app_id);
+  BCT_ACK ack = BCL_register_app_(ti, app_id);
   BCL_clear_info_();
+  return ack;
 }
 
 // TODO: prepare_param系の関数にidx超過のassertionを入れる
@@ -217,17 +224,17 @@ void BCL_tool_prepare_param_double(double val)
 }
 
 
-void BCL_register_cmd_(cycle_t ti, CMD_CODE cmd_id)
+static BCT_ACK BCL_register_cmd_(cycle_t ti, CMD_CODE cmd_id)
 {
   CCP_form_tlc(&block_command_loader_.packet,
                ti,
                cmd_id,
                &block_command_loader_.params[0],
                (uint16_t)block_command_loader_.param_idx);
-  BCT_register_cmd(&block_command_loader_.packet);
+  return BCT_register_cmd(&block_command_loader_.packet);
 }
 
-void BCL_register_cmd_to_other_obc_(cycle_t ti, APID apid, CMD_CODE cmd_id)
+static BCT_ACK BCL_register_cmd_to_other_obc_(cycle_t ti, APID apid, CMD_CODE cmd_id)
 {
   CCP_form_tlc_to_other_obc(&block_command_loader_.packet,
                             ti,
@@ -235,13 +242,13 @@ void BCL_register_cmd_to_other_obc_(cycle_t ti, APID apid, CMD_CODE cmd_id)
                             cmd_id,
                             &block_command_loader_.params[0],
                             (uint16_t)block_command_loader_.param_idx);
-  BCT_register_cmd(&block_command_loader_.packet);
+  return BCT_register_cmd(&block_command_loader_.packet);
 }
 
-void BCL_register_app_(cycle_t ti, AR_APP_ID app_id)
+static BCT_ACK BCL_register_app_(cycle_t ti, AR_APP_ID app_id)
 {
   CCP_form_app_cmd(&block_command_loader_.packet, ti, app_id);
-  BCT_register_cmd(&block_command_loader_.packet);
+  return BCT_register_cmd(&block_command_loader_.packet);
 }
 
 static void BCL_clear_info_(void)

--- a/tlm_cmd/block_command_loader.h
+++ b/tlm_cmd/block_command_loader.h
@@ -37,9 +37,9 @@ void BCL_load_sl(bct_id_t pos, void (*func)(void));
  * @note   ブロックコマンドの定義時に使用する
  * @param  ti         コマンドを実行する相対TI
  * @param  cmd_id     実行するコマンドID
- * @return void
+ * @return BCT_ACK
  */
-void BCL_tool_register_cmd(cycle_t ti, CMD_CODE cmd_id);
+BCT_ACK BCL_tool_register_cmd(cycle_t ti, CMD_CODE cmd_id);
 
 /**
  * @brief  ブロックコマンドの最後に他の OBC のコマンドを追加する
@@ -47,27 +47,27 @@ void BCL_tool_register_cmd(cycle_t ti, CMD_CODE cmd_id);
  * @param  ti         コマンドを実行する相対TI
  * @param  apid       sub OBC を識別する APID
  * @param  cmd_id     実行する sub OBC のコマンドID
- * @return void
+ * @return BCT_ACK
  */
-void BCL_tool_register_cmd_to_other_obc(cycle_t ti, APID apid, CMD_CODE cmd_id);
+BCT_ACK BCL_tool_register_cmd_to_other_obc(cycle_t ti, APID apid, CMD_CODE cmd_id);
 
 /**
  * @brief  ブロックコマンドの最後にローテーターの実行コマンドを追加する
  * @note   ブロックコマンドの定義時に使用する
  * @param  ti         コマンドを実行する相対TI
  * @param  bct_id     ローテートするブロックコマンドID
- * @return void
+ * @return BCT_ACK
  */
-void BCL_tool_register_rotate(cycle_t ti, bct_id_t bct_id);
+BCT_ACK BCL_tool_register_rotate(cycle_t ti, bct_id_t bct_id);
 
 /**
  * @brief  ブロックコマンドの最後にコンバイナーの実行コマンドを追加する
  * @note   ブロックコマンドの定義時に使用する
  * @param  ti         コマンドを実行する相対TI
  * @param  bct_id     コンバインするブロックコマンドID
- * @return void
+ * @return BCT_ACK
  */
-void BCL_tool_register_combine(cycle_t ti, bct_id_t bct_id);
+BCT_ACK BCL_tool_register_combine(cycle_t ti, bct_id_t bct_id);
 
 /**
  * @brief  ブロックコマンドの最後にタイムリミットコンバイナーの実行コマンドを追加する
@@ -75,9 +75,9 @@ void BCL_tool_register_combine(cycle_t ti, bct_id_t bct_id);
  * @param  ti         コマンドを実行する相対TI
  * @param  bct_id     タイムリミットコンバインするブロックコマンドID
  * @param  limit_step 超過すると実行を打ち切るステップ数
- * @return void
+ * @return BCT_ACK
  */
-void BCL_tool_register_limit_combine(cycle_t ti, bct_id_t bct_id, step_t limit_step);
+BCT_ACK BCL_tool_register_limit_combine(cycle_t ti, bct_id_t bct_id, step_t limit_step);
 
 /**
  * @brief  ブロックコマンドの最後にブロックコマンドの展開コマンドを追加する
@@ -85,18 +85,18 @@ void BCL_tool_register_limit_combine(cycle_t ti, bct_id_t bct_id, step_t limit_s
  * @param  ti         コマンドを実行する相対TI
  * @param  bct_id     展開するブロックコマンドID
  * @param  tlcd_id      展開先のタイムラインID
- * @return void
+ * @return BCT_ACK
  */
-void BCL_tool_register_deploy(cycle_t ti, bct_id_t bct_id, TLCD_ID tlcd_id);
+BCT_ACK BCL_tool_register_deploy(cycle_t ti, bct_id_t bct_id, TLCD_ID tlcd_id);
 
 /**
  * @brief  ブロックコマンドの最後にアプリの実行コマンドを追加する
  * @note   BlockCommandDefinitions.cで呼ばれることを想定している
  * @param  ti         コマンドを実行する相対TI
  * @param  app_id     実行するアプリID
- * @return void
+ * @return BCT_ACK
  */
-void BCL_tool_register_app(cycle_t ti, AR_APP_ID app_id);
+BCT_ACK BCL_tool_register_app(cycle_t ti, AR_APP_ID app_id);
 
 
 // add cmd param系列


### PR DESCRIPTION
## Summary

- `BCL_tool_register_cmd` などの BCL 公開 API 7関数の戻り値を `void` → `BCT_ACK` に変更した。
- `BCT_register_cmd` の登録失敗（`BCT_INVALID_CMD_NO`）をユーザーが `BCL_tool_register_hoge` のような関数で検知できるようになる。

## Background

- `BCT_register_cmd` はコマンド登録数が `BCT_MAX_CMD_NUM` を超えると `BCT_INVALID_CMD_NO` を返してサイレントに失敗する。従来の BCL 公開 API はすべて `void` 型だったため、この失敗に気づく手段がなかった。
- なので、Task Listなどを書くときに `BCT_MAX_CMD_NUM` を超える数のコマンドを詰めてしまっても気づきにくい。

## Design Notes

- 後方互換性: C では戻り値の無視は合法なため、既存の `BCL_tool_register_cmd(ti, id);` という呼び出しはそのまま動作する
- EL recordはユーザー任せにする: エラー検知後の EL 記録はユーザーが自分のユーザー定義グループを使って行う

🤖 Generated with [Claude Code](https://claude.com/claude-code)