### PR TITLE
fix(bind-utils): fix doxygen-rs panic on @param colon syntax

### DIFF
--- a/library/bind-utils/src/lib.rs
+++ b/library/bind-utils/src/lib.rs
@@ -8,6 +8,8 @@ struct Cb;
 impl ParseCallbacks for Cb {
     fn process_comment(&self, comment: &str) -> Option<String> {
         let comment = comment.replace("@retval {", "@retval return_value {");
+        // doxygen-rs は @param[in] name: の "name:" をパースできないためコロンを除去
+        let comment = strip_doxygen_param_colon(&comment);
         let dox = doxygen_rs::transform(&comment)
             .trim()
             .replace('[', r"\[")
@@ -18,6 +20,64 @@ impl ParseCallbacks for Cb {
             .join("\n");
         Some(dox)
     }
+}
+
+/// `@param[in] name: desc` や `@param[in]: desc` のコロンを除去する。
+///
+/// doxygen-rs はパラメータ名やディレクション指定の直後にコロンがある形式を
+/// パースできないため、bindgen に渡す前にコロンを取り除く。
+fn strip_doxygen_param_colon(comment: &str) -> String {
+    let mut result = String::with_capacity(comment.len());
+    for line in comment.lines() {
+        if !result.is_empty() {
+            result.push('\n');
+        }
+        // @param を含む行のみ処理
+        if let Some(param_pos) = line.find("@param") {
+            let after_param = &line[param_pos + "@param".len()..];
+            // @param[in]/[out]/[in,out] をスキップ
+            let rest = if after_param.starts_with('[') {
+                match after_param.find(']') {
+                    Some(bracket_end) => &after_param[bracket_end + 1..],
+                    None => {
+                        result.push_str(line);
+                        continue;
+                    }
+                }
+            } else {
+                after_param
+            };
+            // ケース1: @param[in]: desc (パラメータ名なし、コロンが直後)
+            let rest_trimmed = rest.trim_start();
+            if rest_trimmed.starts_with(':') {
+                let colon_pos = param_pos
+                    + "@param".len()
+                    + (after_param.len() - rest.len())
+                    + (rest.len() - rest_trimmed.len());
+                result.push_str(&line[..colon_pos]);
+                result.push_str(&line[colon_pos + 1..]);
+                continue;
+            }
+            // ケース2: @param[in] name: desc (パラメータ名の末尾にコロン)
+            let name_end = rest_trimmed
+                .find(|c: char| !c.is_alphanumeric() && c != '_')
+                .unwrap_or(rest_trimmed.len());
+            if name_end > 0 && rest_trimmed.as_bytes().get(name_end) == Some(&b':') {
+                let colon_pos = param_pos
+                    + "@param".len()
+                    + (after_param.len() - rest.len())
+                    + (rest.len() - rest_trimmed.len())
+                    + name_end;
+                result.push_str(&line[..colon_pos]);
+                result.push_str(&line[colon_pos + 1..]);
+            } else {
+                result.push_str(line);
+            }
+        } else {
+            result.push_str(line);
+        }
+    }
+    result
 }
 
 pub fn bind_c2a_builder() -> bindgen::Builder {


### PR DESCRIPTION
## Summary

- `@param[in] name: desc` や `@param[in]: desc` のようにコロンが含まれる doxygen コメントを bindgen で処理すると、doxygen-rs がパニックする問題を修正
- `process_comment` でコロンを除去する前処理 (`strip_doxygen_param_colon`) を追加

## 背景

c2a-core のヘッダー (`tc_segment.h`, `tc_transfer_frame.h` 等) には `@param[in] tctf: TcTransferFrame` や `@param[in]: TcSegment` 形式の doxygen コメントが存在する。これらのヘッダーを bindgen で処理すると、doxygen-rs (0.4.2) が以下のエラーでパニックする:

```
failed to transform the comments: UnexpectedInput { found: "in]:", expected: ["in]", "out]"] }
```

Doxygen 本体はこの形式を許容するが、doxygen-rs のパーサーはより厳密でコロンを受け付けない。

## 対応内容

`strip_doxygen_param_colon` 関数を追加し、以下の 2 パターンを処理:

1. `@param[in]: desc` → `@param[in] desc` (パラメータ名なし)
2. `@param[in] name: desc` → `@param[in] name desc` (パラメータ名あり)

既存の `@retval {` → `@retval return_value {` の前処理と同じアプローチ。

## Test plan

- [x] c2a-mobc-geox (packet-codec crate) で `tc_transfer_frame.h` を include した状態で `cargo build` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)