### PR TITLE
fix(ci): normalize chardet result case in check_encoding

### DIFF
--- a/script/ci/check_encoding.py
+++ b/script/ci/check_encoding.py
@@ -80,17 +80,20 @@ def check_encoding(path, encoding):
         ret = chardet.detect(f.read())
         enc = ret["encoding"]
     # print(enc)
+    # chardet のバージョンにより返り値の大文字/小文字表記が異なるため正規化して比較する
+    # (例: chardet 6.x は "SHIFT_JIS", 7.x は "cp932" を返す)
+    enc = enc.upper() if enc is not None else None
     if encoding == "utf-8":
-        if enc == "utf-8" or enc == "ascii":
+        if enc == "UTF-8" or enc == "ASCII":
             return True
         # なぜか以下のような誤認もあるので
-        if enc == "Windows-1252" or enc == "ISO-8859-1" or enc is None:
+        if enc == "WINDOWS-1252" or enc == "ISO-8859-1" or enc is None:
             return True
     elif encoding == "shift_jis":
-        if enc == "SHIFT_JIS" or enc == "CP932" or enc == "ascii":
+        if enc == "SHIFT_JIS" or enc == "CP932" or enc == "ASCII":
             return True
         # なぜか以下のような誤認もあるので
-        if enc == "Windows-1252" or enc == "Windows-1254" or enc is None:
+        if enc == "WINDOWS-1252" or enc == "WINDOWS-1254" or enc is None:
             return True
     else:
         print("Invalid encoding in setting file!")


### PR DESCRIPTION
## 概要
`check_encoding` ワークフローが main で赤くなっていた問題を修正します。**コードやファイルの破損ではなく、`chardet` のバージョン差**が原因でした。

## 原因
- ワークフローは `pip install chardet`(バージョン未固定)で chardet を導入。CI が **chardet 7.4.3** を入れるようになった
- chardet 7.x は encoding 名を**小文字**で返す(例: `cp932`)が、6.x は**大文字**だった(`SHIFT_JIS`)
- [check_encoding.py](script/ci/check_encoding.py) の許可リストは `enc == "CP932"` のような**大文字固定の case-sensitive 比較**だったため、正しく Shift_JIS の `.bat` 6ファイル(`examples/{mobc,subobc}/src/src_user/script/` 配下)が invalid と誤判定され、check_encoding が失敗していた
- ファイル自体は正しい Shift_JIS（`.bat` は config の `exceptional_file_config` で shift_jis 許可済み）であり、変更不要

## 修正
検出結果を `.upper()` で正規化してから比較するようにし、作者が元々意図していた許可リスト（CP932/SHIFT_JIS を許可）が chardet のバージョンに依存せず機能するようにした。

## 検証
ローカルで CI と同じ **chardet 7.4.3** を用いて確認:
- 修正前: 該当 `.bat` 6件で FAIL（CI を再現）
- 修正後: `Completed!`（exit 0）。UTF-8 日本語ファイルにも regression なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)