### PR TITLE
test: DriverSuper 送信系・途絶監視・厳格フレーム探索のテストを追加

### DIFF
--- a/component_driver/tests/CMakeLists.txt
+++ b/component_driver/tests/CMakeLists.txt
@@ -60,3 +60,4 @@ endfunction()
 
 add_cds_test(test_stream_rec_buffer test_stream_rec_buffer.cpp)
 add_cds_test(test_frame_analysis test_frame_analysis.cpp)
+add_cds_test(test_send test_send.cpp)

--- a/component_driver/tests/mocks/mock_hal_handler_registry.c
+++ b/component_driver/tests/mocks/mock_hal_handler_registry.c
@@ -13,6 +13,7 @@ static int mock_rx_chunk_size = 0;  // 0 = unlimited
 static uint8_t mock_tx_buffer[4096];
 static int mock_tx_count = 0;
 static int mock_last_tx_size = 0;
+static int mock_tx_result = 0;  // 0 = 成功。エラー注入用
 
 static int mock_hal_init(void* config)
 {
@@ -41,6 +42,7 @@ static int mock_hal_rx(void* config, void* buffer, int buffer_size)
 static int mock_hal_tx(void* config, void* data, int data_size)
 {
   (void)config;
+  if (mock_tx_result != 0) return mock_tx_result;
   if (data_size > (int)sizeof(mock_tx_buffer)) return -1;
 
   memcpy(mock_tx_buffer, data, data_size);
@@ -68,6 +70,7 @@ void mock_hal_reset(void)
   mock_rx_chunk_size = 0;
   mock_tx_count = 0;
   mock_last_tx_size = 0;
+  mock_tx_result = 0;
   memset(mock_rx_buffer, 0, sizeof(mock_rx_buffer));
   memset(mock_tx_buffer, 0, sizeof(mock_tx_buffer));
 }
@@ -101,6 +104,11 @@ void mock_hal_append_rx_data(const uint8_t* data, int len)
 void mock_hal_set_rx_chunk_size(int chunk_size)
 {
   mock_rx_chunk_size = chunk_size;
+}
+
+void mock_hal_set_tx_result(int result)
+{
+  mock_tx_result = result;
 }
 
 int mock_hal_get_tx_count(void) { return mock_tx_count; }

--- a/component_driver/tests/mocks/mock_hal_handler_registry.h
+++ b/component_driver/tests/mocks/mock_hal_handler_registry.h
@@ -32,6 +32,7 @@ void mock_hal_reset(void);
 void mock_hal_set_rx_data(const uint8_t* data, int len);
 void mock_hal_append_rx_data(const uint8_t* data, int len);
 void mock_hal_set_rx_chunk_size(int chunk_size);  // 1回の rx で返す最大バイト数（0=無制限）
+void mock_hal_set_tx_result(int result);          // tx の返り値を注入（0=成功）
 int mock_hal_get_tx_count(void);
 const uint8_t* mock_hal_get_last_tx_data(void);
 int mock_hal_get_last_tx_size(void);

--- a/component_driver/tests/test_frame_analysis.cpp
+++ b/component_driver/tests/test_frame_analysis.cpp
@@ -30,6 +30,8 @@ void mock_hal_set_rx_chunk_size(int chunk_size);
 
 // モック制御用関数の宣言（mock_time_manager.c で定義）
 void mock_time_reset(void);
+void mock_time_set_current(cycle_t total_cycle);
+void mock_time_advance(cycle_t cycles);
 
 }  // extern "C"
 
@@ -56,6 +58,7 @@ protected:
   static uint16_t current_framelength_type_size_;
   static uint16_t current_framelength_offset_;
   static ENDIAN_TYPE current_framelength_endian_;
+  static bool current_strict_frame_search_;
 
   void SetUp() override {
     // モックをリセット
@@ -73,6 +76,7 @@ protected:
     current_framelength_type_size_ = 0;
     current_framelength_offset_ = 0;
     current_framelength_endian_ = ENDIAN_TYPE_BIG;
+    current_strict_frame_search_ = false;
 
     // 受信バッファ初期化
     memset(rx_buffer_mem_, 0, sizeof(rx_buffer_mem_));
@@ -108,6 +112,10 @@ protected:
       CDSSC_set_rx_framelength_type_size(p_stream, current_framelength_type_size_);
       CDSSC_set_rx_framelength_offset(p_stream, current_framelength_offset_);
       CDSSC_set_rx_framelength_endian(p_stream, current_framelength_endian_);
+    }
+
+    if (current_strict_frame_search_) {
+      CDSSC_enable_strict_frame_search(p_stream);
     }
 
     return CDS_ERR_CODE_OK;
@@ -206,6 +214,7 @@ int16_t FrameAnalysisTest::current_framelength_pos_ = -1;
 uint16_t FrameAnalysisTest::current_framelength_type_size_ = 0;
 uint16_t FrameAnalysisTest::current_framelength_offset_ = 0;
 ENDIAN_TYPE FrameAnalysisTest::current_framelength_endian_ = ENDIAN_TYPE_BIG;
+bool FrameAnalysisTest::current_strict_frame_search_ = false;
 
 // ================================================================
 // 固定長フレームテスト
@@ -737,4 +746,150 @@ TEST_F(FrameAnalysisTest, VerifyReceivedFrameContent) {
   EXPECT_EQ(0x22, rx_frame[3]);
   EXPECT_EQ(0x33, rx_frame[4]);
   EXPECT_EQ(0x44, rx_frame[5]);
+}
+
+// ================================================================
+// 厳格なフレーム探索モード (strict frame search)
+// ================================================================
+
+// strict モードはヘッダの存在が前提（validation で弾かれる）
+TEST_F(FrameAnalysisTest, StrictFrameSearchRequiresHeader) {
+  current_strict_frame_search_ = true;
+  current_rx_frame_size_ = 6;  // ヘッダなし固定長
+
+  CDS_ERR_CODE ret = CDS_init(&super_, &dummy_hal_config_, &rx_buffer_, LoadInitSetting);
+  EXPECT_EQ(CDS_ERR_CODE_ERR, ret);
+}
+
+// strict モード: フレーム確定後 1 バイトだけ落とすため、
+// 前フレームの内部に重なったヘッダ候補からのフレームも漏らさず確定する
+TEST_F(FrameAnalysisTest, StrictFrameSearchFindsOverlappedHeader) {
+  const uint8_t header[] = {0xEB, 0x90};
+  current_strict_frame_search_ = true;
+  SetupFixedFrame(header, 2, nullptr, 0, 6);
+
+  // フレーム 1 (EB 90 EB 90 AA BB) の内部 offset 2 に次のヘッダ候補が重なっている
+  uint8_t data[] = {0xEB, 0x90, 0xEB, 0x90, 0xAA, 0xBB, 0xCC, 0xDD};
+  ReceiveData(data, sizeof(data));
+  ASSERT_EQ(CDS_STREAM_REC_STATUS_FIXED_FRAME, GetRecStatusCode());
+
+  // 新規データなしで再受信 → 重なったヘッダ候補からフレーム 2 が確定する
+  mock_hal_set_rx_data(nullptr, 0);
+  CDS_receive(&super_);
+  ASSERT_EQ(CDS_STREAM_REC_STATUS_FIXED_FRAME, GetRecStatusCode());
+
+  const uint8_t* rx_frame = GetRxFrame();
+  ASSERT_NE(nullptr, rx_frame);
+  const uint8_t expected[] = {0xEB, 0x90, 0xAA, 0xBB, 0xCC, 0xDD};
+  EXPECT_EQ(0, memcmp(expected, rx_frame, sizeof(expected)));
+}
+
+// 通常モード: フレーム確定後は確定フレーム全体を落とすため、
+// 前フレーム内部に重なったヘッダ候補は探索されない
+TEST_F(FrameAnalysisTest, NormalSearchSkipsOverlappedHeader) {
+  const uint8_t header[] = {0xEB, 0x90};
+  SetupFixedFrame(header, 2, nullptr, 0, 6);
+
+  uint8_t data[] = {0xEB, 0x90, 0xEB, 0x90, 0xAA, 0xBB, 0xCC, 0xDD};
+  ReceiveData(data, sizeof(data));
+  ASSERT_EQ(CDS_STREAM_REC_STATUS_FIXED_FRAME, GetRecStatusCode());
+
+  // 残りは CC DD のみ（ヘッダなし）→ フレームは確定しない
+  mock_hal_set_rx_data(nullptr, 0);
+  CDS_receive(&super_);
+  EXPECT_NE(CDS_STREAM_REC_STATUS_FIXED_FRAME, GetRecStatusCode());
+}
+
+// ================================================================
+// 受信途絶判定 (rx disruption)
+// ================================================================
+// mock の時刻は OBCT_CYCLES_PER_SEC = 10 なので 1 cycle = 100 ms
+
+// 閾値を超えて受信がないと LOST になる
+TEST_F(FrameAnalysisTest, RxDisruptionDetectedAfterThreshold) {
+  const uint8_t header[] = {0xEB, 0x90};
+  SetupFixedFrame(header, 2, nullptr, 0, 6);
+  CDSC_enable_monitor_for_rx_disruption(&super_);
+  CDSC_set_time_threshold_for_rx_disruption(&super_, 500);
+
+  uint8_t data[] = {0xEB, 0x90, 0x01, 0x02, 0x03, 0x04};
+  ReceiveData(data, sizeof(data));  // rx_time = now (0)
+  EXPECT_EQ(CDS_RX_DISRUPTION_STATUS_OK, CDSC_get_rx_disruption_status(&super_));
+
+  mock_time_advance(6);  // 600 ms > 500 ms
+  mock_hal_set_rx_data(nullptr, 0);
+  CDS_receive(&super_);
+  EXPECT_EQ(CDS_RX_DISRUPTION_STATUS_LOST, CDSC_get_rx_disruption_status(&super_));
+}
+
+// 閾値以内なら OK のまま
+TEST_F(FrameAnalysisTest, RxDisruptionOkWithinThreshold) {
+  const uint8_t header[] = {0xEB, 0x90};
+  SetupFixedFrame(header, 2, nullptr, 0, 6);
+  CDSC_enable_monitor_for_rx_disruption(&super_);
+  CDSC_set_time_threshold_for_rx_disruption(&super_, 500);
+
+  uint8_t data[] = {0xEB, 0x90, 0x01, 0x02, 0x03, 0x04};
+  ReceiveData(data, sizeof(data));
+
+  mock_time_advance(4);  // 400 ms < 500 ms
+  mock_hal_set_rx_data(nullptr, 0);
+  CDS_receive(&super_);
+  EXPECT_EQ(CDS_RX_DISRUPTION_STATUS_OK, CDSC_get_rx_disruption_status(&super_));
+}
+
+// 監視無効なら、どれだけ経過しても OK のまま（テレメのノイズ防止仕様）
+TEST_F(FrameAnalysisTest, RxDisruptionNotMonitoredStaysOk) {
+  const uint8_t header[] = {0xEB, 0x90};
+  SetupFixedFrame(header, 2, nullptr, 0, 6);
+  // 監視は有効化しない
+
+  mock_time_advance(1000);  // 100 秒経過
+  mock_hal_set_rx_data(nullptr, 0);
+  CDS_receive(&super_);
+  EXPECT_EQ(CDS_RX_DISRUPTION_STATUS_OK, CDSC_get_rx_disruption_status(&super_));
+}
+
+// ================================================================
+// テレメ途絶判定 (stream ごとの tlm disruption)
+// ================================================================
+
+// 閾値を超えてフレーム確定がないと LOST になる
+TEST_F(FrameAnalysisTest, TlmDisruptionDetectedAfterThreshold) {
+  const uint8_t header[] = {0xEB, 0x90};
+  SetupFixedFrame(header, 2, nullptr, 0, 6);
+  CDSSC_enable_monitor_for_tlm_disruption(&super_.stream_config[0]);
+  CDSSC_set_time_threshold_for_tlm_disruption(&super_.stream_config[0], 500);
+
+  // フレーム確定 (rx_frame_fix_time = now)
+  uint8_t data[] = {0xEB, 0x90, 0x01, 0x02, 0x03, 0x04};
+  ReceiveData(data, sizeof(data));
+  ASSERT_EQ(CDS_STREAM_REC_STATUS_FIXED_FRAME, GetRecStatusCode());
+  EXPECT_EQ(CDS_STREAM_TLM_DISRUPTION_STATUS_OK,
+            CDSSC_get_tlm_disruption_status(&super_.stream_config[0]));
+
+  mock_time_advance(6);  // 600 ms > 500 ms
+  mock_hal_set_rx_data(nullptr, 0);
+  CDS_receive(&super_);
+  EXPECT_EQ(CDS_STREAM_TLM_DISRUPTION_STATUS_LOST,
+            CDSSC_get_tlm_disruption_status(&super_.stream_config[0]));
+}
+
+// 閾値以内にフレーム確定があれば OK のまま
+TEST_F(FrameAnalysisTest, TlmDisruptionOkWithRecentFrameFix) {
+  const uint8_t header[] = {0xEB, 0x90};
+  SetupFixedFrame(header, 2, nullptr, 0, 6);
+  CDSSC_enable_monitor_for_tlm_disruption(&super_.stream_config[0]);
+  CDSSC_set_time_threshold_for_tlm_disruption(&super_.stream_config[0], 500);
+
+  mock_time_advance(4);  // 400 ms 経過後にフレーム確定
+  uint8_t data[] = {0xEB, 0x90, 0x01, 0x02, 0x03, 0x04};
+  ReceiveData(data, sizeof(data));
+  ASSERT_EQ(CDS_STREAM_REC_STATUS_FIXED_FRAME, GetRecStatusCode());
+
+  mock_time_advance(4);  // 確定から 400 ms < 500 ms
+  mock_hal_set_rx_data(nullptr, 0);
+  CDS_receive(&super_);
+  EXPECT_EQ(CDS_STREAM_TLM_DISRUPTION_STATUS_OK,
+            CDSSC_get_tlm_disruption_status(&super_.stream_config[0]));
 }

--- a/component_driver/tests/test_send.cpp
+++ b/component_driver/tests/test_send.cpp
@@ -1,0 +1,253 @@
+/**
+ * @file test_send.cpp
+ * @brief CDS_send_general_cmd / CDS_send_req_tlm_cmd（送信系）のユニットテスト
+ *
+ * 送信系のテスト:
+ * - 正常送信（HAL に届く内容・send_status・カウンタ・送信時刻）
+ * - 無効 stream / tx フレーム未設定の no-op 動作
+ * - HAL tx エラーの伝播 (TX_ERR)
+ * - 送信前 validation エラー (VALIDATE_ERR)
+ * - req_tlm_cmd_tx_count_after_last_tx のフレーム確定によるリセット
+ */
+#include <gtest/gtest.h>
+#include <cstring>
+
+extern "C" {
+
+// prelude が重い依存を遮断するため、実 driver_super.h をそのまま include する
+#include "driver_super.h"
+
+// モック制御用関数の宣言（mock_hal_handler_registry.c で定義）
+void mock_hal_reset(void);
+void mock_hal_set_rx_data(const uint8_t* data, int len);
+void mock_hal_set_tx_result(int result);
+int mock_hal_get_tx_count(void);
+const uint8_t* mock_hal_get_last_tx_data(void);
+int mock_hal_get_last_tx_size(void);
+
+// モック制御用関数の宣言（mock_time_manager.c で定義）
+void mock_time_reset(void);
+void mock_time_set_current(cycle_t total_cycle);
+
+}  // extern "C"
+
+// ================================================================
+// テストフィクスチャ
+// ================================================================
+
+class SendTest : public ::testing::Test {
+protected:
+  static constexpr uint16_t RX_BUFFER_SIZE = 256;
+  uint8_t rx_buffer_mem_[RX_BUFFER_SIZE];
+  CDS_StreamRecBuffer rx_buffer_;
+  ComponentDriverSuper super_;
+  int dummy_hal_config_;
+
+  // 受信側の設定（validation を通すため最小構成: ヘッダ EB 90 + 固定長 6）
+  static const uint8_t rx_header_[2];
+
+  // 送信側の設定（テスト間で共有する静的データ）
+  static const uint8_t* current_tx_frame_;
+  static int16_t current_tx_frame_size_;
+  static int16_t current_tx_frame_buffer_size_;
+
+  void SetUp() override {
+    mock_hal_reset();
+    mock_time_reset();
+
+    current_tx_frame_ = nullptr;
+    current_tx_frame_size_ = 0;
+    current_tx_frame_buffer_size_ = -1;
+
+    memset(rx_buffer_mem_, 0, sizeof(rx_buffer_mem_));
+    CDS_init_stream_rec_buffer(&rx_buffer_, rx_buffer_mem_, RX_BUFFER_SIZE);
+    memset(&super_, 0, sizeof(super_));
+  }
+
+  void TearDown() override {
+    mock_hal_reset();
+  }
+
+  static CDS_ERR_CODE LoadInitSetting(ComponentDriverSuper* p_super) {
+    CDS_StreamConfig* p_stream = &p_super->stream_config[0];
+
+    p_super->hal_handler_id = HAL_HANDLER_ID_UART;
+    CDSC_set_hal_rx_buffer_size(p_super, RX_BUFFER_SIZE);
+
+    CDSSC_enable(p_stream);
+    CDSSC_set_rx_header(p_stream, rx_header_, sizeof(rx_header_));
+    CDSSC_set_rx_frame_size(p_stream, 6);
+
+    CDSSC_set_tx_frame(p_stream, const_cast<uint8_t*>(current_tx_frame_));
+    CDSSC_set_tx_frame_size(p_stream, current_tx_frame_size_);
+    CDSSC_set_tx_frame_buffer_size(p_stream, current_tx_frame_buffer_size_);
+
+    return CDS_ERR_CODE_OK;
+  }
+
+  void InitSuper() {
+    CDS_ERR_CODE ret = CDS_init(&super_, &dummy_hal_config_, &rx_buffer_, LoadInitSetting);
+    ASSERT_EQ(CDS_ERR_CODE_OK, ret);
+  }
+
+  // ヘルパー: 送信フレーム付きで初期化
+  void SetupWithTxFrame(const uint8_t* frame, int16_t size, int16_t buffer_size = -1) {
+    current_tx_frame_ = frame;
+    current_tx_frame_size_ = size;
+    current_tx_frame_buffer_size_ = buffer_size;
+    InitSuper();
+  }
+
+  CDS_StreamConfig* Stream0() { return &super_.stream_config[0]; }
+
+  CDS_STREAM_SEND_STATUS_CODE GetSendStatusCode() {
+    return CDSSC_get_send_status(Stream0())->status_code;
+  }
+};
+
+const uint8_t SendTest::rx_header_[2] = {0xEB, 0x90};
+const uint8_t* SendTest::current_tx_frame_ = nullptr;
+int16_t SendTest::current_tx_frame_size_ = 0;
+int16_t SendTest::current_tx_frame_buffer_size_ = -1;
+
+// ================================================================
+// CDS_send_general_cmd
+// ================================================================
+
+// 正常送信: HAL に内容どおりのフレームが渡り、status / カウンタが更新される
+TEST_F(SendTest, SendGeneralCmdSuccess) {
+  static const uint8_t tx_frame[] = {0xAA, 0xBB, 0xCC};
+  SetupWithTxFrame(tx_frame, sizeof(tx_frame));
+
+  EXPECT_EQ(CDS_ERR_CODE_OK, CDS_send_general_cmd(&super_, 0));
+
+  EXPECT_EQ(CDS_STREAM_SEND_STATUS_OK, GetSendStatusCode());
+  EXPECT_EQ(1, mock_hal_get_tx_count());
+  EXPECT_EQ(3, mock_hal_get_last_tx_size());
+  EXPECT_EQ(0, memcmp(tx_frame, mock_hal_get_last_tx_data(), sizeof(tx_frame)));
+  EXPECT_EQ(1u, CDSSC_get_general_cmd_tx_count(Stream0()));
+}
+
+// 連続送信でカウンタが累積する
+TEST_F(SendTest, SendGeneralCmdCountsAccumulate) {
+  static const uint8_t tx_frame[] = {0x01, 0x02};
+  SetupWithTxFrame(tx_frame, sizeof(tx_frame));
+
+  CDS_send_general_cmd(&super_, 0);
+  CDS_send_general_cmd(&super_, 0);
+
+  EXPECT_EQ(2, mock_hal_get_tx_count());
+  EXPECT_EQ(2u, CDSSC_get_general_cmd_tx_count(Stream0()));
+}
+
+// 送信時刻が記録される
+TEST_F(SendTest, SendGeneralCmdRecordsTxTime) {
+  static const uint8_t tx_frame[] = {0x01};
+  SetupWithTxFrame(tx_frame, sizeof(tx_frame));
+
+  mock_time_set_current(42);
+  CDS_send_general_cmd(&super_, 0);
+
+  EXPECT_EQ(42u, CDSSC_get_general_cmd_tx_time(Stream0())->total_cycle);
+}
+
+// 無効 stream への送信: OK を返すが DISABLE status で、HAL は呼ばれない
+TEST_F(SendTest, SendGeneralCmdDisabledStream) {
+  static const uint8_t tx_frame[] = {0x01, 0x02};
+  SetupWithTxFrame(tx_frame, sizeof(tx_frame));
+  CDSSC_disable(Stream0());
+
+  EXPECT_EQ(CDS_ERR_CODE_OK, CDS_send_general_cmd(&super_, 0));
+
+  EXPECT_EQ(CDS_STREAM_SEND_STATUS_DISABLE, GetSendStatusCode());
+  EXPECT_EQ(0, mock_hal_get_tx_count());
+  EXPECT_EQ(0u, CDSSC_get_general_cmd_tx_count(Stream0()));
+}
+
+// HAL tx エラー: ERR を返し、TX_ERR status と HAL の返り値が記録される
+TEST_F(SendTest, SendGeneralCmdHalTxError) {
+  static const uint8_t tx_frame[] = {0x01, 0x02};
+  SetupWithTxFrame(tx_frame, sizeof(tx_frame));
+  mock_hal_set_tx_result(-3);
+
+  EXPECT_EQ(CDS_ERR_CODE_ERR, CDS_send_general_cmd(&super_, 0));
+
+  EXPECT_EQ(CDS_STREAM_SEND_STATUS_TX_ERR, GetSendStatusCode());
+  EXPECT_EQ(-3, CDSSC_get_send_status(Stream0())->ret_from_hal_tx);
+  EXPECT_EQ(0, mock_hal_get_tx_count());
+}
+
+// tx フレーム未設定 (size 0): 何も送らずに正常終了する
+TEST_F(SendTest, SendGeneralCmdWithoutTxFrameIsNoop) {
+  InitSuper();  // tx_frame = NULL, size = 0
+
+  EXPECT_EQ(CDS_ERR_CODE_OK, CDS_send_general_cmd(&super_, 0));
+
+  EXPECT_EQ(CDS_STREAM_SEND_STATUS_OK, GetSendStatusCode());
+  EXPECT_EQ(0, mock_hal_get_tx_count());
+}
+
+// 送信前 validation: 初期化後に不正な設定 (frame_size > buffer_size) へ変更すると
+// 送信時の validation で弾かれ、HAL は呼ばれない
+TEST_F(SendTest, SendGeneralCmdValidateErrAfterBadReconfig) {
+  static const uint8_t tx_frame[] = {0x01, 0x02, 0x03};
+  SetupWithTxFrame(tx_frame, sizeof(tx_frame), 8);
+
+  // setter が is_validation_needed_for_send_ を立てる
+  CDSSC_set_tx_frame_size(Stream0(), 9);  // buffer_size (8) を超過
+
+  EXPECT_EQ(CDS_ERR_CODE_ERR, CDS_send_general_cmd(&super_, 0));
+
+  EXPECT_EQ(CDS_STREAM_SEND_STATUS_VALIDATE_ERR, GetSendStatusCode());
+  EXPECT_EQ(0, mock_hal_get_tx_count());
+}
+
+// ================================================================
+// CDS_send_req_tlm_cmd
+// ================================================================
+
+// 正常送信: req tlm 用カウンタ 2 種が更新される
+TEST_F(SendTest, SendReqTlmCmdCountsAndStatus) {
+  static const uint8_t tx_frame[] = {0x10, 0x20};
+  SetupWithTxFrame(tx_frame, sizeof(tx_frame));
+
+  EXPECT_EQ(CDS_ERR_CODE_OK, CDS_send_req_tlm_cmd(&super_, 0));
+
+  EXPECT_EQ(CDS_STREAM_SEND_STATUS_OK, GetSendStatusCode());
+  EXPECT_EQ(1u, CDSSC_get_req_tlm_cmd_tx_count(Stream0()));
+  EXPECT_EQ(1u, CDSSC_get_req_tlm_cmd_tx_count_after_last_tx(Stream0()));
+  EXPECT_EQ(0u, CDSSC_get_general_cmd_tx_count(Stream0()));  // general 側は不変
+}
+
+// 無効 stream への送信: DISABLE status、カウンタ不変
+TEST_F(SendTest, SendReqTlmCmdDisabledStream) {
+  static const uint8_t tx_frame[] = {0x10};
+  SetupWithTxFrame(tx_frame, sizeof(tx_frame));
+  CDSSC_disable(Stream0());
+
+  EXPECT_EQ(CDS_ERR_CODE_OK, CDS_send_req_tlm_cmd(&super_, 0));
+
+  EXPECT_EQ(CDS_STREAM_SEND_STATUS_DISABLE, GetSendStatusCode());
+  EXPECT_EQ(0u, CDSSC_get_req_tlm_cmd_tx_count(Stream0()));
+}
+
+// req_tlm_cmd_tx_count_after_last_tx はテレメフレーム確定でリセットされる
+// (総数 req_tlm_cmd_tx_count は維持される)
+TEST_F(SendTest, ReqTlmCmdCountAfterLastTxResetsOnFrameFix) {
+  static const uint8_t tx_frame[] = {0x10};
+  SetupWithTxFrame(tx_frame, sizeof(tx_frame));
+
+  CDS_send_req_tlm_cmd(&super_, 0);
+  CDS_send_req_tlm_cmd(&super_, 0);
+  EXPECT_EQ(2u, CDSSC_get_req_tlm_cmd_tx_count_after_last_tx(Stream0()));
+
+  // 完全なテレメフレームを受信してフレーム確定させる
+  const uint8_t rx_frame[] = {0xEB, 0x90, 0x01, 0x02, 0x03, 0x04};
+  mock_hal_set_rx_data(rx_frame, sizeof(rx_frame));
+  CDS_receive(&super_);
+  ASSERT_EQ(CDS_STREAM_REC_STATUS_FIXED_FRAME,
+            CDSSC_get_rec_status(Stream0())->status_code);
+
+  EXPECT_EQ(0u, CDSSC_get_req_tlm_cmd_tx_count_after_last_tx(Stream0()));
+  EXPECT_EQ(2u, CDSSC_get_req_tlm_cmd_tx_count(Stream0()));
+}


### PR DESCRIPTION
## モチベーション

#473 の検証（gcov 計測）で、送信系・受信/テレメ途絶監視・厳格フレーム探索が**完全に未テスト**であることが判明した（HAL の tx 記録や時刻制御の mock フックは用意されていたのに未使用だった）。この follow-up でそれらを埋める。

> Note: #473 の stacked PR です。#473 マージ後に base が main へ切り替わります。

## 追加テスト（18 ケース、合計 93 + DISABLED 1）

### 送信系（`test_send.cpp` 新規、10 ケース）
- `CDS_send_general_cmd`: HAL に届くフレーム内容・`send_status`（OK / DISABLE / TX_ERR / VALIDATE_ERR）・カウンタ・送信時刻
- tx フレーム未設定時の no-op、HAL tx エラー伝播、初期化後の不正再設定が送信時 validation で弾かれること
- `CDS_send_req_tlm_cmd`: カウンタ 2 種、`req_tlm_cmd_tx_count_after_last_tx` が**テレメフレーム確定でリセット**される仕様の検証

### 受信途絶・テレメ途絶監視（`test_frame_analysis.cpp` に 5 ケース）
- 閾値超過で LOST / 閾値内で OK / 監視無効なら経過に関わらず OK（rx は super 単位、tlm fix は stream 単位）

### 厳格フレーム探索（同 3 ケース）
- validation でヘッダ必須であること
- **確定フレーム内部に重なったヘッダ候補**を strict モードでは拾い、通常モードではスキップすること

## mock の拡張

- `mock_hal_set_tx_result()`: HAL tx の返り値注入（TX_ERR 経路用）

## カバレッジ

- driver_super.c 行カバレッジ: **67.8% → 82.4%**（未テスト関数 56 → 35）
- 残りは自明な getter/disable 系と、#483 で分離予定の CCP 変換関数のみ

## Test plan
- [x] ローカル: `cargo test -p c2a-core-component-driver` で 93 ケース pass（32bit ビルド）
- [ ] CI rust job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)