### PR TITLE
fix(library): endian/crc の2件の潜在バグ修正 (size_t アンダーフロー / CRC-32 テーブル未初期化)

### DIFF
--- a/library/crc.c
+++ b/library/crc.c
@@ -202,7 +202,7 @@ void CRC_make_crc_32_table(uint32_t* table, uint32_t crc_poly, uint8_t shift)
 {
   int i, j;
 
-  for (i = 0; i < 255; ++i)
+  for (i = 0; i < 256; ++i)
   {
     uint32_t c = (uint32_t)i;
     if (!shift) c <<= 24;

--- a/library/endian.c
+++ b/library/endian.c
@@ -26,7 +26,7 @@ void ENDIAN_conv(void* after, const void* before, size_t size)
   uint8_t* aft = (uint8_t*)after;
   size_t i;
 
-  if (size < 0) return;
+  if (size == 0) return;
 
   size--;
   for (i = 0; i <= size; i++)


### PR DESCRIPTION
## 概要

c2a-core 全体のバグ調査の中で、`library/` の葉関数に再現可能な潜在バグを2件発見したので修正する。どちらも 1 行修正。実ソースを直接コンパイルした再現コードで「壊れる→直る」を確認済み。

## 1. `endian.c` `ENDIAN_conv`: size==0 で size_t アンダーフロー → 範囲外書き込み

```c
if (size < 0) return;   // size_t は符号なしなので常に false(死にコード)
size--;                 // size==0 のとき SIZE_MAX に折り返す
for (i = 0; i <= size; i++) ...   // 巨大ループ + 範囲外書き込み
```

空入力ガードのつもりの `size < 0` が符号なし型で常に false。`size==0` を渡すと `size--` が `SIZE_MAX` になり、反転ループが範囲外へ書き込む。`ENDIAN_memcpy` の実体であり「エンディアン考慮版 memcpy」と銘打たれているのに、`memcpy(dst,src,0)` なら no-op で済む入力でクラッシュする。

- **影響**: `IS_LITTLE_ENDIAN` 定義時(SILS/テストビルド)に `ENDIAN_memcpy → ENDIAN_conv` 経由で発火。現行のコア内呼び出し元は固定の非ゼロサイズのみだが、可変長を渡す将来の呼び出しで 0 になると即死する地雷。
- **修正**: `if (size < 0)` → `if (size == 0)`。

## 2. `crc.c` `CRC_make_crc_32_table`: オフバイワンで table[255] 未初期化

```c
for (i = 0; i < 255; ++i)   // 8bit版・16bit版はどちらも i < 256
```

8bit/16bit 版は `i < 256` なのに 32bit 版だけ `255` で、`table[255]` が未初期化のまま残る(`crc.h` のコメントも「sizeof(table) = 256」と明記)。

- **影響**: 現在 `CRC_make_crc_32_table` の呼び出し元はゼロのため実害は出ていないが、将来 CRC-32 を使い始めると 0xFF で終わるバイトの CRC が壊れる。
- **修正**: `i < 255` → `i < 256`。修正後 `table[255]` は標準 CRC-32 の正規値 `0x2d02ef8d` になることを確認。

## 検証

実ソース(`library/endian.c` / `library/crc.c`)をそのままコンパイルした再現プログラムで確認:

- endian: 修正前は `ENDIAN_conv(dst,src,0)` で **SIGSEGV** → 修正後は no-op で正常リターン(`size=4` のバイト反転は維持)
- crc: 修正前は table[255] が未初期化のまま → 修正後は未初期化 0 件、`table[255] = 0x2d02ef8d`

## 備考

- これらは `library/` の葉関数(依存ほぼ無し)なので、本来は unit test を付けたいが、C コードの unit test 実行基盤は #473 で導入予定。本PRは 2 行修正のみとし、リグレッションテストは #473 マージ後に同じ cargo↔ctest 基盤の上へ追加する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)