### PR TITLE
fix(crc): CRC_make_crc_32_table が table[255] を初期化しない

### DIFF
--- a/library/crc.c
+++ b/library/crc.c
@@ -202,7 +202,7 @@ void CRC_make_crc_32_table(uint32_t* table, uint32_t crc_poly, uint8_t shift)
 {
   int i, j;
 
-  for (i = 0; i < 255; ++i)
+  for (i = 0; i < 256; ++i)
   {
     uint32_t c = (uint32_t)i;
     if (!shift) c <<= 24;


### PR DESCRIPTION
## 概要

`CRC_make_crc_32_table` の生成ループが `for (i = 0; i < 255; ++i)` になっており、`table[255]` が未初期化のまま残る。8bit版・16bit版はどちらも `i < 256` であり、`crc.h` のコメントも「sizeof(table) = 256」と明記している。

```c
for (i = 0; i < 255; ++i)   // ← 255 だと table[255] が埋まらない
```

## 影響

- 現在 `CRC_make_crc_32_table` の呼び出し元はリポジトリ内にゼロのため実害は出ていない。
- ただし将来 CRC-32 を使い始めると、0xFF で終わるバイト（テーブル index 255 を引く入力）の CRC が未初期化のゴミ値で計算され、壊れる。

## 修正

`i < 255` → `i < 256`。

## 検証

実ソース `library/crc.c` をそのままコンパイルした再現プログラムで確認:

- 修正前: table[255] が番兵値のまま（未初期化1件）
- 修正後: 未初期化0件、`table[255] = 0x2d02ef8d`（標準 CRC-32 テーブルの正規値）

## 備考

`library/` の葉関数なので本来は unit test を付けたいが、C コードの unit test 実行基盤は #473 で導入予定。本PRは1行修正のみとし、リグレッションテストは #473 マージ後に同基盤上へ追加する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)