### PR TITLE
fix(endian): ENDIAN_conv が size==0 で size_t アンダーフローし範囲外書き込み

### DIFF
--- a/library/endian.c
+++ b/library/endian.c
@@ -26,12 +26,12 @@ void ENDIAN_conv(void* after, const void* before, size_t size)
   uint8_t* aft = (uint8_t*)after;
   size_t i;
 
-  if (size < 0) return;
-
-  size--;
-  for (i = 0; i <= size; i++)
+  // size == 0 は memcpy(dst, src, 0) と同様に no-op（反転すべきデータが無い）。
+  // i < size のループにすることで size == 0 が自然に no-op になり，
+  // 符号なし size_t に対する size-- アンダーフローも構造的に起こり得ない。
+  for (i = 0; i < size; i++)
   {
-    *(aft + (size - i)) = *(bef + i);
+    aft[size - 1 - i] = bef[i];
   }
 
   return;


### PR DESCRIPTION
## 概要
`ENDIAN_conv(after, before, size)` は `size == 0` で `size_t` アンダーフローを起こし、範囲外書き込みでクラッシュする。

```c
if (size < 0) return;   // (a) size_t は符号なし → 常に false の死にコード
size--;                 // (b) size==0 で SIZE_MAX に折り返す
for (i = 0; i <= size; i++) *(aft + (size - i)) = *(bef + i);  // 範囲外書き込み
```

`ENDIAN_conv` は `ENDIAN_memcpy`（`IS_LITTLE_ENDIAN` 時の実体）が委譲する先。「エンディアン考慮版 memcpy」を謳うのに、`memcpy(dst,src,0)` なら no-op で済む入力でクラッシュする。

## 修正
`size--` をやめ、アンダーフローしないループに書き換える（ガード追加ではなく失敗モードを構造的に除去）。

```c
for (i = 0; i < size; i++) aft[size - 1 - i] = bef[i];
```

- `size==0` → ループが回らず no-op
- `size>0` → 従来と同じバイト反転（ビット単位で等価）
- `size--` 不在でアンダーフロー不可能、死にコード `if (size < 0)` も除去

## size==0 を no-op にした理由
- **memcpy 準拠**: `memcpy(_,_,0)` は well-defined な no-op。memcpy にエラー概念は無く、memcpy 互換を謳う以上 no-op が契約通り（エラー化すると互換から外れる）。
- **エラーを足さない**: 葉プリミティブは引数だけでは NULL/長さ超過を検知できず、戻り値を増やしても危険ケースは捕まらない。「0 が来てはいけない」かは呼び出し側の関心事（現状 0 を渡す呼び出し元も `ENDIAN_conv` の直接呼び出し元も無い）。
- **慣習**: core は `assert()` を使わず葉関数は benign 値を返す（例: `ascii2hex` は不正文字に `0x00`）。
- 意図が消えないよう no-op の旨をコードコメントにも明記。

## 影響 / 検証
- 発火は `IS_LITTLE_ENDIAN`（SILS/テスト）ビルドのみ。実機（big-endian）は `ENDIAN_memcpy→memcpy` で無関係。現状の呼び出し元は固定非ゼロサイズだが、可変長で 0 が来ると即死する地雷。
- 再現: 実 `library/endian.c` をコンパイルした再現プログラムで、修正前 `ENDIAN_conv(dst,src,0)` → **SIGSEGV**、修正後 → no-op（size=4 の反転は維持）、**ASan+UBSan 警告なし**。

## 備考
`library/` 葉関数の unit test 基盤は #473 で導入予定。本PRは実装修正のみ、リグレッションテストは #473 マージ後に同基盤上へ追加する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)