### PR TITLE
fix(boom-tools): pass --locked to cargo-binstall

### DIFF
--- a/examples/mobc/boom-tools/install.sh
+++ b/examples/mobc/boom-tools/install.sh
@@ -5,13 +5,13 @@ export JRSONNET_VERSION="v0.5.0-pre96-test"
 
 curl -L --proto '=https' --tlsv1.2 -sSf "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/${BINSTALL_VERSION}/install-from-binstall-release.sh" | env BINSTALL_VERSION=${BINSTALL_VERSION} CARGO_HOME=$(pwd) bash
 
-./bin/cargo-binstall --root . tmtc-c2a               --version 1.1.1 --no-confirm
+./bin/cargo-binstall --root . tmtc-c2a               --version 1.1.1 --no-confirm --locked
 
-./bin/cargo-binstall --root . tlmcmddb-cli           --version 2.6.1 --no-confirm
-./bin/cargo-binstall --root . kble                   --version 0.4.2 --no-confirm
-./bin/cargo-binstall --root . kble-serialport        --version 0.4.2 --no-confirm
-./bin/cargo-binstall --root . kble-c2a               --version 0.4.2 --no-confirm
-./bin/cargo-binstall --root . kble-eb90              --version 0.4.2 --no-confirm
+./bin/cargo-binstall --root . tlmcmddb-cli           --version 2.6.1 --no-confirm --locked
+./bin/cargo-binstall --root . kble                   --version 0.4.2 --no-confirm --locked
+./bin/cargo-binstall --root . kble-serialport        --version 0.4.2 --no-confirm --locked
+./bin/cargo-binstall --root . kble-c2a               --version 0.4.2 --no-confirm --locked
+./bin/cargo-binstall --root . kble-eb90              --version 0.4.2 --no-confirm --locked
 
 ## install jrsonnet
 arch=$(uname -m)

--- a/examples/subobc/boom-tools/install.sh
+++ b/examples/subobc/boom-tools/install.sh
@@ -5,13 +5,13 @@ export JRSONNET_VERSION="v0.5.0-pre96-test"
 
 curl -L --proto '=https' --tlsv1.2 -sSf "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/${BINSTALL_VERSION}/install-from-binstall-release.sh" | env BINSTALL_VERSION=${BINSTALL_VERSION} CARGO_HOME=$(pwd) bash
 
-./bin/cargo-binstall --root . tmtc-c2a               --version 1.1.1 --no-confirm
+./bin/cargo-binstall --root . tmtc-c2a               --version 1.1.1 --no-confirm --locked
 
-./bin/cargo-binstall --root . tlmcmddb-cli           --version 2.6.1 --no-confirm
-./bin/cargo-binstall --root . kble                   --version 0.4.2 --no-confirm
-./bin/cargo-binstall --root . kble-serialport        --version 0.4.2 --no-confirm
-./bin/cargo-binstall --root . kble-c2a               --version 0.4.2 --no-confirm
-./bin/cargo-binstall --root . kble-eb90              --version 0.4.2 --no-confirm
+./bin/cargo-binstall --root . tlmcmddb-cli           --version 2.6.1 --no-confirm --locked
+./bin/cargo-binstall --root . kble                   --version 0.4.2 --no-confirm --locked
+./bin/cargo-binstall --root . kble-serialport        --version 0.4.2 --no-confirm --locked
+./bin/cargo-binstall --root . kble-c2a               --version 0.4.2 --no-confirm --locked
+./bin/cargo-binstall --root . kble-eb90              --version 0.4.2 --no-confirm --locked
 
 ## install jrsonnet
 arch=$(uname -m)


### PR DESCRIPTION
## 概要

pytest CI が稀に setup 段階で落ちる flake の修正その 1。boom-tools の `install.sh` で cargo-binstall に `--locked` を渡す。

## 背景・原因

直近の pytest 失敗 2 件([main の run](https://github.com/arkedge/c2a-core/actions/runs/27195772753)、[PR の run](https://github.com/arkedge/c2a-core/actions/runs/27272871496))はいずれも同一パターンで、テスト本体ではなく `c2a-boom-tools` preinstall での失敗だった:

1. cargo-binstall の fetcher (QuickInstall / GitHub) がネットワーク不調で `WARN resolve: Timeout reached while checking fetcher ...: deadline has elapsed` になる
2. binstall が「プレビルドバイナリなし」と判断し、`cargo install tmtc-c2a --version 1.1.1` の**ソースビルドに fallback** する
3. `--locked` がないため推移的依存が最新で解決され、edition 2024 の crate(6/9 は clap_derive 4.6.1 = MSRV 1.85、6/10 は time-macros 0.2.27 = MSRV 1.88)を引いてしまう
4. リポジトリは Rust **1.81.0** に pin されているため、cargo が manifest をパースできず `failed to parse manifest` で確実に失敗する

つまり「タイムアウト(確率的)× fallback ビルドが現在は必ず失敗(決定的)」の合せ技。昔は fallback でも(遅いだけで)ビルドが通っていたが、edition 2024 crate の普及で fallback = 即死になり顕在化した。

## 修正

`--locked` を渡すと、fallback の `cargo install` が各 crate 同梱の Cargo.lock を使うため、pin された toolchain で再現性のあるビルドになる。プレビルドバイナリが取得できる通常パスの挙動は変わらない。

mobc / subobc の install.sh は同一内容なので両方に適用した。

なお、fallback 自体を避けるためのバイナリキャッシュ導入は別 PR で行う(そちらと本 PR は install.sh で軽微に conflict するため、先にマージされた方に追従して rebase する)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)