### PR TITLE
ci: cache c2a-boom-tools binaries in pytest workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -58,15 +58,11 @@ jobs:
         cache: pnpm
         cache-dependency-path: examples/${{ matrix.c2a_user }}/pnpm-lock.yaml
 
-    - name: Cache C2A devtools
-      id: cache-c2a-devtools
+    - name: Cache C2A Boom tools
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
-        path: |
-          ./examples/mobc/tools/bin
-          ./examples/mobc/tools/.crates.toml
-          ./examples/mobc/tools/.crates2.json
-        key: ${{ matrix.c2a_user }}-${{ runner.os }}-tools-${{ hashFiles('${{ matrix.c2a_user }}/tools/install.sh', '${{ matrix.c2a_user }}/tools/package.json') }}
+        path: ${{ runner.temp }}/c2a-boom-tools
+        key: ${{ runner.os }}-boom-tools-${{ hashFiles('examples/mobc/boom-tools/install.sh') }}
 
     - name: Get Rust toolchain
       id: toolchain
@@ -97,6 +93,8 @@ jobs:
 
     - name: the heaviest objects in universe
       working-directory: ./examples/mobc
+      env:
+        C2A_BOOM_TOOLS_CACHE_DIR: ${{ runner.temp }}/c2a-boom-tools
       run: |
         pnpm install --frozen-lockfile
 

--- a/examples/mobc/boom-tools/install.sh
+++ b/examples/mobc/boom-tools/install.sh
@@ -3,6 +3,25 @@
 export BINSTALL_VERSION="v1.10.14"
 export JRSONNET_VERSION="v0.5.0-pre96-test"
 
+BIN_NAMES=(tmtc-c2a tlmcmddb-cli kble kble-serialport kble-c2a kble-eb90 jrsonnet)
+
+## restore binaries from cache & skip network access entirely (for CI)
+## NOTE: cache invalidation relies on the cache key hashing this script (tool versions are defined above)
+if [ -n "${C2A_BOOM_TOOLS_CACHE_DIR:-}" ]; then
+  cache_complete=true
+  for name in "${BIN_NAMES[@]}"; do
+    [ -x "${C2A_BOOM_TOOLS_CACHE_DIR}/${name}" ] || cache_complete=false
+  done
+  if "${cache_complete}"; then
+    mkdir -p ./bin
+    for name in "${BIN_NAMES[@]}"; do
+      cp "${C2A_BOOM_TOOLS_CACHE_DIR}/${name}" "./bin/${name}"
+    done
+    echo "c2a-boom-tools: restored binaries from ${C2A_BOOM_TOOLS_CACHE_DIR}"
+    exit 0
+  fi
+fi
+
 curl -L --proto '=https' --tlsv1.2 -sSf "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/${BINSTALL_VERSION}/install-from-binstall-release.sh" | env BINSTALL_VERSION=${BINSTALL_VERSION} CARGO_HOME=$(pwd) bash
 
 ./bin/cargo-binstall --root . tmtc-c2a               --version 1.1.1 --no-confirm
@@ -21,3 +40,11 @@ fi
 os=$(uname -s | tr -s '[:upper:]' '[:lower:]')
 curl -L "https://github.com/CertainLach/jrsonnet/releases/download/${JRSONNET_VERSION}/jrsonnet-linux-${arch}" -o ./bin/jrsonnet
 chmod +x ./bin/jrsonnet
+
+## save binaries to cache (for CI)
+if [ -n "${C2A_BOOM_TOOLS_CACHE_DIR:-}" ]; then
+  mkdir -p "${C2A_BOOM_TOOLS_CACHE_DIR}"
+  for name in "${BIN_NAMES[@]}"; do
+    cp "./bin/${name}" "${C2A_BOOM_TOOLS_CACHE_DIR}/${name}"
+  done
+fi

--- a/examples/subobc/boom-tools/install.sh
+++ b/examples/subobc/boom-tools/install.sh
@@ -3,6 +3,25 @@
 export BINSTALL_VERSION="v1.10.14"
 export JRSONNET_VERSION="v0.5.0-pre96-test"
 
+BIN_NAMES=(tmtc-c2a tlmcmddb-cli kble kble-serialport kble-c2a kble-eb90 jrsonnet)
+
+## restore binaries from cache & skip network access entirely (for CI)
+## NOTE: cache invalidation relies on the cache key hashing this script (tool versions are defined above)
+if [ -n "${C2A_BOOM_TOOLS_CACHE_DIR:-}" ]; then
+  cache_complete=true
+  for name in "${BIN_NAMES[@]}"; do
+    [ -x "${C2A_BOOM_TOOLS_CACHE_DIR}/${name}" ] || cache_complete=false
+  done
+  if "${cache_complete}"; then
+    mkdir -p ./bin
+    for name in "${BIN_NAMES[@]}"; do
+      cp "${C2A_BOOM_TOOLS_CACHE_DIR}/${name}" "./bin/${name}"
+    done
+    echo "c2a-boom-tools: restored binaries from ${C2A_BOOM_TOOLS_CACHE_DIR}"
+    exit 0
+  fi
+fi
+
 curl -L --proto '=https' --tlsv1.2 -sSf "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/${BINSTALL_VERSION}/install-from-binstall-release.sh" | env BINSTALL_VERSION=${BINSTALL_VERSION} CARGO_HOME=$(pwd) bash
 
 ./bin/cargo-binstall --root . tmtc-c2a               --version 1.1.1 --no-confirm
@@ -21,3 +40,11 @@ fi
 os=$(uname -s | tr -s '[:upper:]' '[:lower:]')
 curl -L "https://github.com/CertainLach/jrsonnet/releases/download/${JRSONNET_VERSION}/jrsonnet-linux-${arch}" -o ./bin/jrsonnet
 chmod +x ./bin/jrsonnet
+
+## save binaries to cache (for CI)
+if [ -n "${C2A_BOOM_TOOLS_CACHE_DIR:-}" ]; then
+  mkdir -p "${C2A_BOOM_TOOLS_CACHE_DIR}"
+  for name in "${BIN_NAMES[@]}"; do
+    cp "./bin/${name}" "${C2A_BOOM_TOOLS_CACHE_DIR}/${name}"
+  done
+fi


### PR DESCRIPTION
## 概要

pytest CI が稀に setup 段階で落ちる flake の修正その 2(その 1 は #488)。boom-tools のバイナリ群を actions/cache でキャッシュし、キャッシュヒット時は preinstall が**ネットワークに一切出ない**ようにする。

## 背景

#488 に書いたとおり、flake の入口は cargo-binstall の fetcher のネットワークタイムアウト。#488 はタイムアウト後の fallback ビルドを直すものだが、本 PR はそもそも毎回のダウンロード自体を不要にして、ネットワーク起因の失敗確率と CI 時間を下げる。

## 変更内容

- `install.sh`(mobc / subobc 共通): `C2A_BOOM_TOOLS_CACHE_DIR` が設定されている場合、
  - 全 7 バイナリがそこに揃っていれば `./bin/` に復元して即終了(cargo-binstall のダウンロードも含めて network access ゼロ)
  - 揃っていなければ従来どおりインストールし、最後にキャッシュへ保存
  - 未設定時(ローカル)は従来と完全に同一の挙動
- `pytest.yml`:
  - 既存の "Cache C2A devtools" ステップを置き換え。このステップは `examples/mobc/tools/`(`boom-tools/` への改名前のパス)を参照しており、**実際には何もキャッシュしていなかった**(hashFiles の対象も存在しないため key も縮退していた)
  - キャッシュ key は `install.sh` の hashFiles。ツールのバージョンはすべて `install.sh` 内に書かれているので、バージョン更新時に自然に key が変わる
  - matrix 全 9 job で同一 key を共有(preinstall が走るのはどの job でも `examples/mobc` のため)

## 動作確認

ローカルで restore パス(完全キャッシュ → 復元して即終了、ネットワーク不要)と miss パス(欠けあり → 通常インストールへ進む)の両方を確認済み。

## 備考

- #488 と本 PR は `install.sh` で軽微に conflict するので、先にマージされた方に追従して rebase する
- 初回キャッシュ作成時の同時 job 競合は actions/cache が良きに計らう(最初に Post 処理に到達した job が保存し、他は保存スキップ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)