### PR TITLE
feat(dev-runtime): 実時間との同期粒度を 100ms から 1ms に細分化

### DIFF
--- a/dev-runtime/src/lib.rs
+++ b/dev-runtime/src/lib.rs
@@ -1,7 +1,13 @@
-use std::{env, sync::LazyLock, thread, time};
+use std::{env, num::NonZeroU32, sync::LazyLock, thread, time};
 
-const UPDATE_BATCH_SIZE: usize = 100;
-const DEFAULT_UPDATE_BATCH_IN_REALTIME: time::Duration = time::Duration::from_millis(100);
+/// OBCT_STEP_IN_MSEC 相当
+const STEP_IN_REALTIME: time::Duration = time::Duration::from_millis(1);
+
+/// 実時間と同期する間隔 (step 数)．C2A の時刻はこの step 数ぶんまで実時間に先行する
+const DEFAULT_SYNC_INTERVAL_IN_STEP: u32 = 1;
+
+/// これ以上遅れたら，時間の回復は諦める (デバッガでの停止など)
+const CATCH_UP_LIMIT: time::Duration = time::Duration::from_millis(100);
 
 static SPEED_MULTIPLIER: LazyLock<f64> = LazyLock::new(|| {
     let multiplier = env::var("C2A_DEV_RUNTIME_SPEED")
@@ -19,10 +25,17 @@ static SPEED_MULTIPLIER: LazyLock<f64> = LazyLock::new(|| {
     multiplier
 });
 
-static UPDATE_INTERVAL: LazyLock<time::Duration> = LazyLock::new(|| {
-    let base_millis = DEFAULT_UPDATE_BATCH_IN_REALTIME.as_millis() as f64;
-    let adjusted_millis = (base_millis / *SPEED_MULTIPLIER).max(1.0) as u64;
-    time::Duration::from_millis(adjusted_millis)
+static SYNC_INTERVAL_IN_STEP: LazyLock<u32> = LazyLock::new(|| {
+    env::var("C2A_DEV_RUNTIME_SYNC_STEPS")
+        .ok()
+        .and_then(|v| v.parse::<NonZeroU32>().ok())
+        .map(NonZeroU32::get)
+        .unwrap_or(DEFAULT_SYNC_INTERVAL_IN_STEP)
+});
+
+static SYNC_INTERVAL: LazyLock<time::Duration> = LazyLock::new(|| {
+    let interval = STEP_IN_REALTIME * *SYNC_INTERVAL_IN_STEP;
+    interval.div_f64(*SPEED_MULTIPLIER)
 });
 
 pub fn c2a_init() {
@@ -47,19 +60,23 @@ pub fn c2a_init() {
 pub fn c2a_main() {
     use c2a_core::*;
 
+    // sleep の起床遅れが積み上がらないよう，目標時刻は前回の目標時刻から積算する
+    let mut next_sync = time::Instant::now() + *SYNC_INTERVAL;
+
     loop {
-        let start = time::Instant::now();
-        for _ in 0..UPDATE_BATCH_SIZE {
+        for _ in 0..*SYNC_INTERVAL_IN_STEP {
             unsafe {
                 system::time_manager::TMGR_count_up_master_clock();
                 C2A_core_main();
             }
         }
-        let elapsed_time = start.elapsed();
-        if elapsed_time < *UPDATE_INTERVAL {
-            let duration_to_sleep = *UPDATE_INTERVAL - elapsed_time;
-            thread::sleep(duration_to_sleep);
+
+        let now = time::Instant::now();
+        match next_sync.checked_duration_since(now) {
+            Some(duration_to_sleep) => thread::sleep(duration_to_sleep),
+            None if now - next_sync > CATCH_UP_LIMIT => next_sync = now,
+            None => {}
         }
-        // FIXME: 時間がめっちゃ遅れてたときの時間回復は一旦しない
+        next_sync += *SYNC_INTERVAL;
     }
 }


### PR DESCRIPTION
## 概要
dev-runtime の実時間との同期を，100ms 単位から 1ms (1 step) 単位に細かくする．

## Issue
- 特になし

## 詳細
従来は 100 step (= 100ms 相当) をバースト実行してから残り時間を sleep していたため，C2A の master clock は実時間に対して最大 100ms 先行していた．これを 1 step ごとの同期に変更する．

同期頻度を上げると 1 周期あたりの sleep の起床遅れ (数十 us) が無視できなくなるため，あわせて以下を変更した．

1. sleep の目標時刻を「実時刻からの残り時間」ではなく「前回の目標時刻からの積算」とした．起床遅れが毎周期積み上がって C2A の時刻が徐々に遅れることがなくなる．
2. 同期間隔の ms 整数丸め (`(100.0 / speed).max(1.0) as u64`) を撤去し，`div_f64` によるサブ ms 精度にした．丸めのため `C2A_DEV_RUNTIME_SPEED` に非整数分割となる値や 100 倍速超を指定した場合に，指定どおりの速度が出ていなかった．
3. 実時間に対する遅れが 100ms (`CATCH_UP_LIMIT`) を超えたら，時間の回復を諦めることにした．デバッガでの中断後に遅れを取り戻そうとして全力で回り続けるのを防ぐ (従来の FIXME コメントの明文化)．
4. 同期間隔を `C2A_DEV_RUNTIME_SYNC_STEPS` (既定 `1`) で変更できるようにした．sleep 精度が良くない環境や sleep 回数を抑えたい場合に `100` を指定すると従来相当になる．`0` や解釈できない値は既定値にフォールバックする．

## 検証結果
測定環境は WSL2 (Linux 5.15) 上の Linux，`examples/mobc` の debug ビルド．

### 実バイナリの同期回数

`/proc/<pid>/status` の `voluntary_ctxt_switches` から測定．

| 設定 | 同期回数 | CPU |
| --- | --- | --- |
| 既定 (`SYNC_STEPS=1`) | 約 1000 回/s | 1.5% |
| `SYNC_STEPS=10` | 100.0 回/s | 0.5% |
| `SYNC_STEPS=100` (従来相当) | 10.0 回/s | 0.1% |
| `SPEED=2` | 2002.0 回/s | 2.6% |
| `SPEED=0.5` | 500.3 回/s | 0.7% |

### 「C2A の時刻 − 実時間」の最大乖離

同一アルゴリズムを切り出したハーネスで，step 単位で測定 (5s 実行)．

| | 従来 (100 step 単位) | 本 PR (1 step 単位) |
| --- | --- | --- |
| `SPEED=1` | 先行 100.0ms / rate 100.0% | 先行 **1.0ms** / rate 100.0% |
| `SPEED=3` | 先行 72.8ms / rate **101.3%** | 先行 0.33ms / rate 100.0% |
| `SPEED=200` | rate **47.5%** | rate 100.0% |

### 1 step が同期間隔 (1ms) を超える場合

3s 実行．実時間どおりなら 1000 step/s．

| ケース | 従来 | 本 PR |
| --- | --- | --- |
| 常に 1 step = 3ms | 333.3 step/s | 332.7 step/s |
| 100 step に 1 回 5ms | 1000.0 step/s (最大乖離 2.6ms) | 1000.0 step/s (最大乖離 4.2ms，連続無 sleep 5 step) |
| 常に 1 step = 0.9ms | 1000.0 step/s (最大乖離 2.6ms) | 1000.0 step/s (最大乖離 0.4ms，連続無 sleep 8 step) |

単発の超過は次の数 step が sleep 無しで連続実行され，平均レートは維持される．バースト長の上限は `CATCH_UP_LIMIT / STEP_IN_REALTIME` = 100 step で，これは従来が毎周期実行していた長さと同じ．恒常的に超過する場合は出せる速度で回り，従来と同じ挙動になる．

また，デバッガでの中断を模擬して 2 秒停止させた場合，復帰後は実時間レートで再開し，停止中の 2000 step を一気に消化しない (`CATCH_UP_LIMIT` が無いと消化してしまう)．

`cargo fmt --all -- --check` / `cargo clippy --workspace --all-features --locked` / `cargo test --workspace` / `script/ci/check_encoding.py` は通っている (clippy の警告 2 件は本 PR 対象外の既存分)．

## 影響範囲
- dev-runtime を使った SILS 実行のみ．実機ビルドや S2E には影響しない．
- 公開 API の変更は無く，C2A user 側での対応は不要．
- 既定の sleep 回数が 10 回/s から約 1000 回/s に増える (実測での CPU 使用率は 0.1% → 1.5% 程度)．重い場合は `C2A_DEV_RUNTIME_SYNC_STEPS` で戻せる．
- `C2A_DEV_RUNTIME_SPEED` に非整数分割となる値や 100 超を指定していた場合，実際の実行速度が変わる (指定どおりになる)．
- 1 step = 1ms (`OBCT_STEP_IN_MSEC` が 1) を前提にしている点は従来と同じ．

## 補足
- CHANGELOG はリリース時にまとめて更新されている運用に見えたため，本 PR では触っていない．
- `docs/sils/c2a_dev_runtime.md` への環境変数 2 つの説明追記は含めていない．必要なら追記する．

🤖 Generated with [Claude Code](https://claude.com/claude-code)
